### PR TITLE
Change backtick to double quote for getIdentifierQuoteString

### DIFF
--- a/src/main/java/software/aws/neptune/jdbc/DatabaseMetaData.java
+++ b/src/main/java/software/aws/neptune/jdbc/DatabaseMetaData.java
@@ -98,7 +98,7 @@ public abstract class DatabaseMetaData implements java.sql.DatabaseMetaData {
 
     @Override
     public String getIdentifierQuoteString() {
-        return "`";
+        return "\"";
     }
 
     @Override

--- a/src/test/java/software/aws/neptune/jdbc/DatabaseMetaDataTest.java
+++ b/src/test/java/software/aws/neptune/jdbc/DatabaseMetaDataTest.java
@@ -153,7 +153,7 @@ public class DatabaseMetaDataTest {
                 java.sql.DatabaseMetaData.sqlStateSQL);
         HelperFunctions.expectFunctionDoesntThrow(() -> databaseMetaData.getProcedureTerm(), "");
         HelperFunctions.expectFunctionDoesntThrow(() -> databaseMetaData.getSchemaTerm(), "");
-        HelperFunctions.expectFunctionDoesntThrow(() -> databaseMetaData.getIdentifierQuoteString(), "`");
+        HelperFunctions.expectFunctionDoesntThrow(() -> databaseMetaData.getIdentifierQuoteString(), "\"");
         HelperFunctions
                 .expectFunctionDoesntThrow(() -> databaseMetaData.getRowIdLifetime(), RowIdLifetime.ROWID_UNSUPPORTED);
 


### PR DESCRIPTION
### Summary

Change backtick to double quote for getIdentifierQuoteString

### Description

[1] Changing backtick to double quote.

### Related Issue

https://bitquill.atlassian.net/browse/AN-835

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
