### PR TITLE
Remove Catalog support

### DIFF
--- a/src/main/java/software/aws/neptune/NeptuneDatabaseMetadata.java
+++ b/src/main/java/software/aws/neptune/NeptuneDatabaseMetadata.java
@@ -45,7 +45,7 @@ public class NeptuneDatabaseMetadata extends DatabaseMetaData implements java.sq
 
     @Override
     public String getCatalogTerm() throws SQLException {
-        return "graph";
+        return "";
     }
 
     @Override

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetCatalogs.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetCatalogs.java
@@ -35,7 +35,7 @@ public abstract class ResultSetGetCatalogs extends ResultSetGetString {
     private static final Map<String, String> CONVERSION_MAP = new HashMap<>();
 
     static {
-        CONVERSION_MAP.put("TABLE_CAT", "catalog");
+        CONVERSION_MAP.put("TABLE_CAT", null);
     }
 
     /**
@@ -44,7 +44,7 @@ public abstract class ResultSetGetCatalogs extends ResultSetGetString {
      * @param statement Statement Object.
      */
     public ResultSetGetCatalogs(final Statement statement) {
-        super(statement, ImmutableList.of("TABLE_CAT"), 1, ImmutableList.of(CONVERSION_MAP));
+        super(statement, ImmutableList.of("TABLE_CAT"), 0, ImmutableList.of(CONVERSION_MAP));
     }
 
     protected List<String> getColumns() {

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetSchemas.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetSchemas.java
@@ -34,7 +34,7 @@ public abstract class ResultSetGetSchemas extends ResultSetGetString {
 
     static {
         CONVERSION_MAP.put("TABLE_SCHEM", "gremlin");
-        CONVERSION_MAP.put("TABLE_CAT", "catalog");
+        CONVERSION_MAP.put("TABLE_CAT", null);
     }
 
     /**

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetString.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetString.java
@@ -31,6 +31,7 @@ public abstract class ResultSetGetString extends GenericResultSet {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResultSetGetString.class);
     private final List<String> columns;
     private final List<Map<String, String>> constantReturns;
+    private boolean wasNull = false;
 
     /**
      * ResultSetGetString constructor, initializes super class.
@@ -59,9 +60,16 @@ public abstract class ResultSetGetString extends GenericResultSet {
         }
         final String key = columns.get(columnIndex - 1);
         if (constantReturns.get(index).containsKey(key)) {
-            return constantReturns.get(index).get(key);
+            final Object value = constantReturns.get(index).get(key);
+            wasNull = value == null;
+            return value;
         } else {
             throw SqlError.createSQLFeatureNotSupportedException(LOGGER);
         }
+    }
+
+    @Override
+    public boolean wasNull() throws SQLException {
+        return this.wasNull;
     }
 }

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherDatabaseMetadataTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherDatabaseMetadataTest.java
@@ -148,8 +148,8 @@ public class OpenCypherDatabaseMetadataTest {
     @Test
     void testGetCatalogs() throws SQLException {
         final java.sql.ResultSet resultSet = databaseMetaData.getCatalogs();
-        Assertions.assertTrue(resultSet.next());
-        // TODO: Fix this to check the value later.
+        // Catalog is not currently supported
+        Assertions.assertFalse(resultSet.next());
     }
 
     @Test

--- a/src/test/java/software/aws/neptune/sparql/SparqlDatabaseMetadataTest.java
+++ b/src/test/java/software/aws/neptune/sparql/SparqlDatabaseMetadataTest.java
@@ -92,7 +92,8 @@ public class SparqlDatabaseMetadataTest {
     @Test
     void testGetCatalogs() throws SQLException {
         final java.sql.ResultSet resultSet = databaseMetaData.getCatalogs();
-        Assertions.assertTrue(resultSet.next());
+        // Catalog is not currently supported
+        Assertions.assertFalse(resultSet.next());
     }
 
     @Test


### PR DESCRIPTION
### Summary

Remove Catalog support

### Description

`getCatalogTerm` now returns an empty string instead of `graph`

I am unsure if this is the full extent of the changes required. A blanket search for methods that include the term `catalog` shows that the only logic that seems to have an actual function is in `DatabaseMetaData` describing the following:

```
public ResultSet getCatalogs() throws SQLException {
    LOGGER.info("Getting database catalogs.");
    return connection.getQueryExecutor().executeGetCatalogs(getConnection().createStatement());
}
```

This indicates to me that it's more related to a query regarding Catalogs that is a separate concept?

All tests ran and passed locally.

### Related Issue

https://bitquill.atlassian.net/browse/AN-863

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
