### PR TITLE
[AN-893] Tableau Connector Name Change

### DIFF
--- a/tableau-connector/src/manifest.xml
+++ b/tableau-connector/src/manifest.xml
@@ -2,7 +2,7 @@
 
 <connector-plugin class='neptune-jdbc' superclass='jdbc' plugin-version='1.13.0.0' name='Amazon Neptune' version='18.1' min-version-tableau='2020.3'>
     <vendor-information>
-        <company name="AWS"/>
+        <company name="Amazon Web Services"/>
         <support-link url="https://docs.aws.amazon.com/neptune/latest/userguide/intro.html"/>
         <driver-download-link url="https://docs.aws.amazon.com/neptune/latest/userguide/intro.html"/>
     </vendor-information>


### PR DESCRIPTION
Changed AWS to Amazon Web Services

### Summary
Tableau Connector Renaming

### Description
AWS can not be used in Tableau Connector, all references to AWS should be renamed to Amazon Web Services.
Updated name will be presented like on the picture below - 

![image (3)](https://user-images.githubusercontent.com/7035336/142574926-84712877-3b8c-49e7-86dc-ab926fb73fc9.png)
![image (5)](https://user-images.githubusercontent.com/7035336/142574953-31c2aac5-54fe-4ffa-9f9b-427050fcabdf.png)

### Related Issue
[AN-893](https://bitquill.atlassian.net/browse/AN-893)

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
