### PR TITLE
Fixing Tableau Extract Error

### DIFF
--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/SqlConverter.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/SqlConverter.java
@@ -72,10 +72,10 @@ public class SqlConverter {
                 .traitDefs(TRAIT_DEFS)
                 .programs(PROGRAM)
                 .build();
-        GremlinSqlFactory.setSqlMetadata(new SqlMetadata(gremlinSchema));
     }
 
     private GremlinSqlSelect getSelect(final GraphTraversalSource g, final String query) throws SQLException {
+        GremlinSqlFactory.setSqlMetadata(new SqlMetadata(gremlinSchema));
         final QueryPlanner queryPlanner = new QueryPlanner(frameworkConfig);
         queryPlanner.plan(query);
         final SqlNode sqlNode = queryPlanner.getValidate();

--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/SqlMetadata.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/SqlMetadata.java
@@ -50,7 +50,6 @@ import java.util.Set;
 @Getter
 public class SqlMetadata {
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlMetadata.class);
-    private final GraphTraversalSource g;
     private final GremlinSchema gremlinSchema;
     private final Map<String, String> tableRenameMap = new HashMap<>();
     private final Map<String, String> columnRenameMap = new HashMap<>();
@@ -60,8 +59,7 @@ public class SqlMetadata {
     private boolean isAggregate = false;
     private boolean isGrouped = false;
 
-    public SqlMetadata(final GraphTraversalSource g, final GremlinSchema gremlinSchema) {
-        this.g = g;
+    public SqlMetadata(final GremlinSchema gremlinSchema) {
         this.gremlinSchema = gremlinSchema;
     }
 

--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/results/pagination/Pagination.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/results/pagination/Pagination.java
@@ -60,14 +60,14 @@ public class Pagination implements Runnable {
             }
             // If we run out of traversal data (or hit our limit), stop and signal to the result that it is done.
             sqlGremlinQueryResult.assertIsEmpty();
-            closeTraversal();
         } catch (final Exception e) {
-            closeTraversal();
             final StringWriter sw = new StringWriter();
             final PrintWriter pw = new PrintWriter(sw);
             e.printStackTrace(pw);
             LOGGER.error("Encountered exception", e);
             sqlGremlinQueryResult.setPaginationException(new SQLException(e + sw.toString()));
+        } finally {
+            closeTraversal();
         }
     }
 

--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/results/pagination/Pagination.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/results/pagination/Pagination.java
@@ -60,12 +60,21 @@ public class Pagination implements Runnable {
             }
             // If we run out of traversal data (or hit our limit), stop and signal to the result that it is done.
             sqlGremlinQueryResult.assertIsEmpty();
+            closeTraversal();
         } catch (final Exception e) {
+            closeTraversal();
             final StringWriter sw = new StringWriter();
             final PrintWriter pw = new PrintWriter(sw);
             e.printStackTrace(pw);
             LOGGER.error("Encountered exception", e);
             sqlGremlinQueryResult.setPaginationException(new SQLException(e + sw.toString()));
+        }
+    }
+
+    void closeTraversal() {
+        try {
+            traversal.close();
+        } catch (final Exception ignored) {
         }
     }
 

--- a/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlBaseTest.java
+++ b/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlBaseTest.java
@@ -45,13 +45,13 @@ public abstract class GremlinSqlBaseTest {
         graph = TestGraphFactory.createGraph(getDataSet());
         g = graph.traversal();
         final GremlinSchema gremlinSchema = SqlSchemaGrabber.getSchema(g, SqlSchemaGrabber.ScanType.All);
-        converter = new SqlConverter(gremlinSchema, g);
+        converter = new SqlConverter(gremlinSchema);
     }
 
     protected abstract DataSet getDataSet();
 
     protected void runQueryTestColumnType(final String query) throws SQLException {
-        final SqlGremlinQueryResult sqlGremlinQueryResult = converter.executeQuery(query);
+        final SqlGremlinQueryResult sqlGremlinQueryResult = converter.executeQuery(g, query);
         final int columnCount = sqlGremlinQueryResult.getColumns().size();
         final SqlGremlinTestResult result = new SqlGremlinTestResult(sqlGremlinQueryResult);
         final List<Class<?>> returnedColumnType = new ArrayList<>();
@@ -100,13 +100,13 @@ public abstract class GremlinSqlBaseTest {
     protected void runQueryTestResults(final String query, final List<String> columnNames,
                                        final List<List<?>> rows)
             throws SQLException {
-        final SqlGremlinTestResult result = new SqlGremlinTestResult(converter.executeQuery(query));
+        final SqlGremlinTestResult result = new SqlGremlinTestResult(converter.executeQuery(g, query));
         assertRows(result.getRows(), rows);
         assertColumns(result.getColumns(), columnNames);
     }
 
     protected void runQueryTestThrows(final String query, final String errorMessage) {
-        Assertions.assertThrows(SQLException.class, () -> converter.executeQuery(query), errorMessage);
+        Assertions.assertThrows(SQLException.class, () -> converter.executeQuery(g, query), errorMessage);
     }
 
     @SafeVarargs

--- a/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinQueryExecutor.java
+++ b/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinQueryExecutor.java
@@ -44,7 +44,7 @@ import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalS
 public class SqlGremlinQueryExecutor extends GremlinQueryExecutor {
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlGremlinQueryExecutor.class);
     private static final Object TRAVERSAL_LOCK = new Object();
-    private static SqlConverter gremlinSqlConverter = null;
+    private SqlConverter gremlinSqlConverter = null;
     private static GraphTraversalSource graphTraversalSource = null;
     private final GremlinConnectionProperties gremlinConnectionProperties;
 
@@ -80,7 +80,7 @@ public class SqlGremlinQueryExecutor extends GremlinQueryExecutor {
         GremlinQueryExecutor.close();
     }
 
-    private static GraphTraversalSource getGraphTraversalSource(
+    private GraphTraversalSource getGraphTraversalSource(
             final GremlinConnectionProperties gremlinConnectionProperties)
             throws SQLException {
         synchronized (TRAVERSAL_LOCK) {
@@ -93,12 +93,11 @@ public class SqlGremlinQueryExecutor extends GremlinQueryExecutor {
 
     }
 
-    private static SqlConverter getGremlinSqlConverter(final GremlinConnectionProperties gremlinConnectionProperties)
+    private SqlConverter getGremlinSqlConverter(final GremlinConnectionProperties gremlinConnectionProperties)
             throws SQLException {
         MetadataCache.updateCacheIfNotUpdated(gremlinConnectionProperties);
         if (gremlinSqlConverter == null) {
-            gremlinSqlConverter = new SqlConverter(MetadataCache.getGremlinSchema(),
-                    getGraphTraversalSource(gremlinConnectionProperties));
+            gremlinSqlConverter = new SqlConverter(MetadataCache.getGremlinSchema());
         }
         return gremlinSqlConverter;
     }
@@ -173,7 +172,7 @@ public class SqlGremlinQueryExecutor extends GremlinQueryExecutor {
     @Override
     @SuppressWarnings("unchecked")
     protected <T> T runQuery(final String query) {
-        return (T) getGremlinSqlConverter(gremlinConnectionProperties).executeQuery(query);
+        return (T) getGremlinSqlConverter(gremlinConnectionProperties).executeQuery(getGraphTraversalSource(gremlinConnectionProperties), query);
     }
 
     // TODO AN-540: Look into query cancellation.

--- a/src/test/java/software/aws/neptune/gremlin/sql/SqlGremlinTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/sql/SqlGremlinTest.java
@@ -629,13 +629,12 @@ public class SqlGremlinTest {
         final List<GremlinVertexTable> vertices = gremlinVertexTablesFuture.get();
         final List<GremlinEdgeTable> edges = gremlinEdgeTablesFuture.get();
         final GremlinSchema gremlinSchema = new GremlinSchema(vertices, edges);
-        final SqlConverter sqlConverter =
-                new SqlConverter(gremlinSchema, traversal().withRemote(DriverRemoteConnection.using(client)));
-        SqlGremlinQueryResult result = sqlConverter.executeQuery("SELECT airport.city AS c FROM airport");
+        final SqlConverter sqlConverter = new SqlConverter(gremlinSchema);
+        SqlGremlinQueryResult result = sqlConverter.executeQuery(traversal().withRemote(DriverRemoteConnection.using(client)), "SELECT airport.city AS c FROM airport");
         System.out.println("Columns: " + result.getColumns());
-        result = sqlConverter.executeQuery("SELECT city AS c FROM airport");
+        result = sqlConverter.executeQuery(traversal().withRemote(DriverRemoteConnection.using(client)), "SELECT city AS c FROM airport");
         System.out.println("Columns: " + result.getColumns());
-        result = sqlConverter.executeQuery("SELECT city FROM airport HAVING (COUNT(1) > 0)");
+        result = sqlConverter.executeQuery(traversal().withRemote(DriverRemoteConnection.using(client)), "SELECT city FROM airport HAVING (COUNT(1) > 0)");
         System.out.println("Columns: " + result.getColumns());
     }
 


### PR DESCRIPTION
### Summary

Fixing Tableau Extract Error

### Description

[1] Fixed some logic around connection pooling.
[2] As discussed with Alexey, this is non-trivial to test and we will brainstorm a way to test this on Monday after GA release. For now we will rely on manual testing done by Yang, Alexey and Lyndon using Tableau.

> Connection pool within TinkerPop was the connection pool that was throwing an exception.
> SqlGremlinQueryExecutor held a static SqlConverter, which was given a GraphTraversalSource upon instantiation. This was then used to run Traversals as they came.
> Close function would then close that GraphTraversalSource on the SqlGremlinQueryExecutor, so next query comes along and TinkerPop (library that implements GraphTraversalSource) would throw an exception saying that their connection pool is shutdown.
> Close still closes the GraphTraversalSource (because it should), but now each query gets a fresh GraphTraversalSource to work off of, and it is regenerated if it is closed, then invoked again 

### Related Issue

https://bitquill.atlassian.net/browse/AN-879

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
