### PR TITLE
Tableau Data Preview Error Fixes

### DIFF
--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlAsOperator.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlAsOperator.java
@@ -90,6 +90,8 @@ public class GremlinSqlAsOperator extends GremlinSqlOperator {
             return ((GremlinSqlIdentifier) sqlOperands.get(0)).getColumn();
         } else if (sqlOperands.get(0) instanceof GremlinSqlBasicCall) {
             return ((GremlinSqlBasicCall) sqlOperands.get(0)).getActual();
+        } else if (sqlOperands.get(0) instanceof GremlinSqlLiteral) {
+            return ((GremlinSqlLiteral) sqlOperands.get(0)).getValue().toString();
         }
         throw new SQLException("Error, unable to get actual name in GremlinSqlAsOperator.");
     }

--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/operator/aggregate/GremlinSqlAggFunction.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/operator/aggregate/GremlinSqlAggFunction.java
@@ -83,6 +83,9 @@ public class GremlinSqlAggFunction extends GremlinSqlOperator {
             if (sqlOperands.get(0) instanceof GremlinSqlIdentifier) {
                 SqlTraversalEngine.applySqlIdentifier((GremlinSqlIdentifier) sqlOperands.get(0), sqlMetadata,
                         graphTraversal);
+            } else if (sqlOperands.get(0) instanceof GremlinSqlLiteral) {
+                GremlinSqlLiteral gremlinSqlLiteral = (GremlinSqlLiteral) sqlOperands.get(0);
+                gremlinSqlLiteral.appendTraversal(graphTraversal);
             }
         }
         if (AGGREGATE_APPENDERS.containsKey(sqlAggFunction.kind)) {

--- a/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlAdvancedSelectTest.java
+++ b/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlAdvancedSelectTest.java
@@ -20,6 +20,7 @@
 package org.twilmes.sql.gremlin.adapter;
 
 import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
 import java.sql.SQLException;
 
 /**
@@ -248,34 +249,28 @@ public class GremlinSqlAdvancedSelectTest extends GremlinSqlBaseTest {
         // Tableau was sending queries like this for the preview in 2021.3
         runQueryTestResults("SELECT SUM(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
-                rows(r(6)));
+                rows(r(new BigDecimal(6))));
         runQueryTestResults("SELECT MIN(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
-                rows(r(1)));
+                rows(r(new BigDecimal(1))));
         runQueryTestResults("SELECT MAX(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
-                rows(r(1)));
+                rows(r(new BigDecimal(1))));
         runQueryTestResults("SELECT AVG(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
-                rows(r(1)));
-        runQueryTestResults("SELECT 1 AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
-                columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
-                rows(r(1)));
+                rows(r(new BigDecimal(1))));
 
-        runQueryTestResults("SELECT SUM(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+        runQueryTestResults("SELECT SUM(2) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
-                rows(r(12)));
-        runQueryTestResults("SELECT MIN(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                rows(r(new BigDecimal(12))));
+        runQueryTestResults("SELECT MIN(2) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
-                rows(r(2)));
-        runQueryTestResults("SELECT MAX(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                rows(r(new BigDecimal(2))));
+        runQueryTestResults("SELECT MAX(2) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
-                rows(r(2)));
-        runQueryTestResults("SELECT AVG(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                rows(r(new BigDecimal(2))));
+        runQueryTestResults("SELECT AVG(2) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
-                rows(r(2)));
-        runQueryTestResults("SELECT 1 AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
-                columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
-                rows(r(2)));
+                rows(r(new BigDecimal(2))));
     }
 }

--- a/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlAdvancedSelectTest.java
+++ b/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlAdvancedSelectTest.java
@@ -242,4 +242,40 @@ public class GremlinSqlAdvancedSelectTest extends GremlinSqlBaseTest {
         // NULLS FIRST predicate is not currently supported.
         runQueryTestThrows("SELECT name FROM \"gremlin\".\"person\" ORDER BY name NULLS FIRST", "Error, no appropriate order for GremlinSqlPostFixOperator of NULLS_FIRST.");
     }
+
+    @Test
+    void testAggregateLiteralHavingNoGroupBy() throws SQLException {
+        // Tableau was sending queries like this for the preview in 2021.3
+        runQueryTestResults("SELECT SUM(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
+                rows(r(6)));
+        runQueryTestResults("SELECT MIN(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
+                rows(r(1)));
+        runQueryTestResults("SELECT MAX(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
+                rows(r(1)));
+        runQueryTestResults("SELECT AVG(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
+                rows(r(1)));
+        runQueryTestResults("SELECT 1 AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
+                rows(r(1)));
+
+        runQueryTestResults("SELECT SUM(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
+                rows(r(12)));
+        runQueryTestResults("SELECT MIN(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
+                rows(r(2)));
+        runQueryTestResults("SELECT MAX(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
+                rows(r(2)));
+        runQueryTestResults("SELECT AVG(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
+                rows(r(2)));
+        runQueryTestResults("SELECT 1 AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+                columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
+                rows(r(2)));
+    }
 }

--- a/tableau-connector/src/dialect.tdd
+++ b/tableau-connector/src/dialect.tdd
@@ -73,6 +73,36 @@
       <unagg-formula>%1</unagg-formula>
       <argument type='int' />
     </function>
+    <function group='aggregate' name='COUNT' return-type='int'>
+      <formula>COUNT(%1)</formula>
+      <unagg-formula>%1</unagg-formula>
+      <argument type='bool' />
+    </function>
+    <function group='aggregate' name='COUNT' return-type='int'>
+      <formula>COUNT(%1)</formula>
+      <unagg-formula>%1</unagg-formula>
+      <argument type='real' />
+    </function>
+    <function group='aggregate' name='COUNT' return-type='int'>
+      <formula>COUNT(%1)</formula>
+      <unagg-formula>%1</unagg-formula>
+      <argument type='str' />
+    </function>
+    <function group='aggregate' name='COUNT' return-type='int'>
+      <formula>COUNT(%1)</formula>
+      <unagg-formula>%1</unagg-formula>
+      <argument type='datetime' />
+    </function>
+    <function group='aggregate' name='AVG' return-type='real'>
+      <formula>AVG(%1)</formula>
+      <unagg-formula>%1</unagg-formula>
+      <argument type='real' />
+    </function>
+    <function group='aggregate' name='AVG' return-type='real'>
+      <formula>AVG(%1)</formula>
+      <unagg-formula>%1</unagg-formula>
+      <argument type='int' />
+    </function>
     <function group='operator' name='!' return-type='bool'>
       <formula>(NOT %1)</formula>
       <argument type='bool' />


### PR DESCRIPTION
### Summary

Tableau Data Preview Error Fixes

### Description

[1] Tableau Data Preview was giving an error that COUNT was not found
[2] After the COUNT was found issue was resolved (by adding it to dialect file) it gave an error with the query that was being executed. The query in question was a SUM(<literal>) query. This exposed an issue with <aggregate>(<literal>) queries in the sql-gremlin library, which is corrected in these changes.
[3] Alexey also noted that AVG was reported as unsupported in Tableau, so I added it to the dialect file as well.

### Related Issue

https://bitquill.atlassian.net/browse/AN-894

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
