### PR TITLE
Print all logs when assembling Tableau Connector

### DIFF
--- a/tableau-connector/build.sh
+++ b/tableau-connector/build.sh
@@ -14,7 +14,7 @@ echo TARGET_FOLDER=${TARGET_FOLDER}
 mkdir -p $TARGET_FOLDER
 
 echo "Building Docker Image"
-docker build -t taco-builder $CURRENT_FOLDER
+docker build -t taco-builder $CURRENT_FOLDER --progress=plain --no-cache
 
 echo "Assembling Tableau Connector"
 docker run -d -it --name=taco-builder --mount type=bind,source=$TARGET_FOLDER,target=/output taco-builder


### PR DESCRIPTION
### Summary
Tableau Connector Build log enhancements

### Description
Adding 2 parameters when building Tableau Connector:
`--progress=plain` - prints logs in console
`--no-cache` - removes caching of the images

### Related Issue
https://bitquill.atlassian.net/browse/AN-896

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
