### PR TITLE
Fixed exception in DBVisualizer for LIMIT 1 queries.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,7 @@ task writeProperties(type: WriteProperties) {
 jacoco {
     toolVersion = "0.8.5"
 }
+
 jacocoTestReport {
     reports {
         html.enabled true
@@ -259,7 +260,7 @@ dependencies {
 
     // Testing
     testImplementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
-    testImplementation  group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jupiterVersion
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jupiterVersion
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.0.0'

--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/results/pagination/Pagination.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/results/pagination/Pagination.java
@@ -59,7 +59,7 @@ public class Pagination implements Runnable {
                 convertAndInsertResult(sqlGremlinQueryResult, rows);
             }
             // If we run out of traversal data (or hit our limit), stop and signal to the result that it is done.
-            sqlGremlinQueryResult.assertIsEmpty();
+            sqlGremlinQueryResult.close();
         } catch (final Exception e) {
             final StringWriter sw = new StringWriter();
             final PrintWriter pw = new PrintWriter(sw);

--- a/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlAdvancedSelectTest.java
+++ b/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlAdvancedSelectTest.java
@@ -241,36 +241,82 @@ public class GremlinSqlAdvancedSelectTest extends GremlinSqlBaseTest {
                 rows(r("Tom"), r("Susan"), r("Phil"), r("Pavel"), r("Patty"), r("Juanita")));
 
         // NULLS FIRST predicate is not currently supported.
-        runQueryTestThrows("SELECT name FROM \"gremlin\".\"person\" ORDER BY name NULLS FIRST", "Error, no appropriate order for GremlinSqlPostFixOperator of NULLS_FIRST.");
+        runQueryTestThrows("SELECT name FROM \"gremlin\".\"person\" ORDER BY name NULLS FIRST",
+                "Error, no appropriate order for GremlinSqlPostFixOperator of NULLS_FIRST.");
     }
 
     @Test
     void testAggregateLiteralHavingNoGroupBy() throws SQLException {
         // Tableau was sending queries like this for the preview in 2021.3
-        runQueryTestResults("SELECT SUM(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+        runQueryTestResults(
+                "SELECT SUM(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
                 rows(r(new BigDecimal(6))));
-        runQueryTestResults("SELECT MIN(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+        runQueryTestResults(
+                "SELECT MIN(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
                 rows(r(new BigDecimal(1))));
-        runQueryTestResults("SELECT MAX(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+        runQueryTestResults(
+                "SELECT MAX(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
                 rows(r(new BigDecimal(1))));
-        runQueryTestResults("SELECT AVG(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+        runQueryTestResults(
+                "SELECT AVG(1) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
                 rows(r(new BigDecimal(1))));
 
-        runQueryTestResults("SELECT SUM(2) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+        runQueryTestResults(
+                "SELECT SUM(2) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
                 rows(r(new BigDecimal(12))));
-        runQueryTestResults("SELECT MIN(2) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+        runQueryTestResults(
+                "SELECT MIN(2) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
                 rows(r(new BigDecimal(2))));
-        runQueryTestResults("SELECT MAX(2) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+        runQueryTestResults(
+                "SELECT MAX(2) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
                 rows(r(new BigDecimal(2))));
-        runQueryTestResults("SELECT AVG(2) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
+        runQueryTestResults(
+                "SELECT AVG(2) AS \"cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok\" FROM gremlin.person AS person HAVING COUNT(1) > 0",
                 columns("cnt:airport_03C2E834E28942D3AA2423AC01F4B33D:ok"),
                 rows(r(new BigDecimal(2))));
+    }
+
+    @Test
+    void testLimit() throws SQLException {
+        // LIMIT 1 tests.
+        // Single result query.
+        runQueryTestResults("SELECT name, age FROM person WHERE name = 'Tom' ORDER BY age LIMIT 1",
+                columns("name", "age"),
+                rows(r("Tom", 35)));
+        // Multi result query.
+        runQueryTestResults("SELECT name, age FROM person ORDER BY age LIMIT 1",
+                columns("name", "age"),
+                rows(r("Patty", 29)));
+
+        // LIMIT > 1 tests.
+        runQueryTestResults("SELECT name, age FROM person WHERE name <> 'Tom' ORDER BY age LIMIT 2",
+                columns("name", "age"),
+                rows(r("Patty", 29), r("Pavel", 30)));
+        runQueryTestResults("SELECT name, age FROM person WHERE name <> 'Tom' ORDER BY age LIMIT 3",
+                columns("name", "age"),
+                rows(r("Patty", 29), r("Pavel", 30), r("Phil", 31)));
+        runQueryTestResults("SELECT name, age FROM person WHERE name <> 'Tom' ORDER BY age LIMIT 4",
+                columns("name", "age"),
+                rows(r("Patty", 29), r("Pavel", 30), r("Phil", 31), r("Susan", 45)));
+        runQueryTestResults("SELECT name, age FROM person WHERE name <> 'Tom' ORDER BY age LIMIT 5",
+                columns("name", "age"),
+                rows(r("Patty", 29), r("Pavel", 30), r("Phil", 31), r("Susan", 45), r("Juanita", 50)));
+        runQueryTestResults("SELECT name, age FROM person WHERE name <> 'Tom' ORDER BY age LIMIT 6",
+                columns("name", "age"),
+                rows(r("Patty", 29), r("Pavel", 30), r("Phil", 31), r("Susan", 45), r("Juanita", 50)));
+        runQueryTestResults("SELECT name, age FROM person WHERE name <> 'Tom' ORDER BY age LIMIT 1000",
+                columns("name", "age"),
+                rows(r("Patty", 29), r("Pavel", 30), r("Phil", 31), r("Susan", 45), r("Juanita", 50)));
+        runQueryTestResults(
+                String.format("SELECT name, age FROM person WHERE name <> 'Tom' ORDER BY age LIMIT %d", Long.MAX_VALUE),
+                columns("name", "age"),
+                rows(r("Patty", 29), r("Pavel", 30), r("Phil", 31), r("Susan", 45), r("Juanita", 50)));
     }
 }

--- a/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlBaseTest.java
+++ b/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlBaseTest.java
@@ -151,20 +151,12 @@ public abstract class GremlinSqlBaseTest {
 
         SqlGremlinTestResult(final SqlGremlinQueryResult sqlGremlinQueryResult) throws SQLException {
             columns = sqlGremlinQueryResult.getColumns();
-            Object res;
             do {
-                try {
-                    res = sqlGremlinQueryResult.getResult();
-                } catch (final SQLException e) {
-                    if (e.getMessage().equals(SqlGremlinQueryResult.EMPTY_MESSAGE)) {
-                        break;
-                    } else {
-                        throw e;
-                    }
+                final List<?> res = sqlGremlinQueryResult.getResult();
+                if (res instanceof SqlGremlinQueryResult.EmptyResult) {
+                    break;
                 }
-                if (res instanceof List<?>) {
-                    this.rows.add((List<?>) res);
-                }
+                this.rows.add(res);
             } while (true);
         }
     }

--- a/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlBaseTest.java
+++ b/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlBaseTest.java
@@ -151,13 +151,13 @@ public abstract class GremlinSqlBaseTest {
 
         SqlGremlinTestResult(final SqlGremlinQueryResult sqlGremlinQueryResult) throws SQLException {
             columns = sqlGremlinQueryResult.getColumns();
+            List<?> res;
             do {
-                final List<?> res = sqlGremlinQueryResult.getResult();
-                if (res instanceof SqlGremlinQueryResult.EmptyResult) {
-                    break;
+                res = sqlGremlinQueryResult.getResult();
+                if (!(res instanceof SqlGremlinQueryResult.EmptyResult)) {
+                    this.rows.add(res);
                 }
-                this.rows.add(res);
-            } while (true);
+            } while (!(res instanceof SqlGremlinQueryResult.EmptyResult));
         }
     }
 }

--- a/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinResultSet.java
+++ b/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinResultSet.java
@@ -19,7 +19,6 @@ package software.aws.neptune.gremlin.sql;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.twilmes.sql.gremlin.adapter.results.SqlGremlinQueryResult;
-import software.aws.neptune.common.EmptyResultSet;
 import software.aws.neptune.common.gremlindatamodel.resultset.ResultSetGetColumns;
 import software.aws.neptune.gremlin.GremlinTypeMapping;
 import software.aws.neptune.gremlin.resultset.GremlinResultSetMetadata;

--- a/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinResultSet.java
+++ b/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinResultSet.java
@@ -19,9 +19,9 @@ package software.aws.neptune.gremlin.sql;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.twilmes.sql.gremlin.adapter.results.SqlGremlinQueryResult;
+import software.aws.neptune.common.EmptyResultSet;
 import software.aws.neptune.common.gremlindatamodel.resultset.ResultSetGetColumns;
 import software.aws.neptune.gremlin.GremlinTypeMapping;
-import software.aws.neptune.gremlin.resultset.GremlinResultSet;
 import software.aws.neptune.gremlin.resultset.GremlinResultSetMetadata;
 import software.aws.neptune.jdbc.ResultSet;
 import software.aws.neptune.jdbc.utilities.SqlError;
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public class SqlGremlinResultSet extends ResultSet implements java.sql.ResultSet {
-    private static final Logger LOGGER = LoggerFactory.getLogger(GremlinResultSet.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlGremlinResultSet.class);
 
     private final List<String> columns;
     private final List<String> columnTypes;
@@ -79,15 +79,9 @@ public class SqlGremlinResultSet extends ResultSet implements java.sql.ResultSet
     @Override
     public boolean next() throws SQLException {
         final Object res;
-        try {
-            res = sqlQueryResult.getResult();
-        } catch (final SQLException e) {
-            if (e.getMessage().equals(SqlGremlinQueryResult.EMPTY_MESSAGE)) {
-                LOGGER.trace(SqlGremlinQueryResult.EMPTY_MESSAGE);
-                return false;
-            } else {
-                throw e;
-            }
+        res = sqlQueryResult.getResult();
+        if (res instanceof SqlGremlinQueryResult.EmptyResult) {
+            return false;
         }
         this.row = (List<Object>) res;
         return true;

--- a/src/main/java/software/aws/neptune/jdbc/utilities/ConnectionProperties.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/ConnectionProperties.java
@@ -59,7 +59,7 @@ public abstract class ConnectionProperties extends Properties {
     public static final int DEFAULT_CONNECTION_TIMEOUT_MILLIS = 5000;
     public static final int DEFAULT_CONNECTION_RETRY_COUNT = 3;
     public static final String DEFAULT_SSH_STRICT_CHECKING = "true";
-    public static final Level DEFAULT_LOG_LEVEL = Level.ALL;
+    public static final Level DEFAULT_LOG_LEVEL = Level.OFF;
     public static final String DEFAULT_SERVICE_REGION = "";
 
     public static final Map<String, Object> DEFAULT_PROPERTIES_MAP = new HashMap<>();

--- a/src/main/java/software/aws/neptune/jdbc/utilities/ConnectionProperties.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/ConnectionProperties.java
@@ -59,7 +59,7 @@ public abstract class ConnectionProperties extends Properties {
     public static final int DEFAULT_CONNECTION_TIMEOUT_MILLIS = 5000;
     public static final int DEFAULT_CONNECTION_RETRY_COUNT = 3;
     public static final String DEFAULT_SSH_STRICT_CHECKING = "true";
-    public static final Level DEFAULT_LOG_LEVEL = Level.OFF;
+    public static final Level DEFAULT_LOG_LEVEL = Level.ALL;
     public static final String DEFAULT_SERVICE_REGION = "";
 
     public static final Map<String, Object> DEFAULT_PROPERTIES_MAP = new HashMap<>();


### PR DESCRIPTION
### Summary

Fixed exception in DBVisualizer for LIMIT 1 queries.

### Description

Limit 1 was giving intermittent exceptions in DBVisualizer. I investigated this for a while and found the root cause. Due to some timing with LIMIT 1, the interrupt (intended to unblock our BlockingQueue) was interrupting the ResultSet retrieval thread of DBVisualizer.

DBVisualizer was then reporting an error, even though all the results were properly retrieved.

To fix this I did changed the BlockingQueue unblock mechanism to use a specified extension of the List<Object> interface I made, which denotes that there are no more results. This removes the need for try/catch logic, synchronized blocks, over overall reduces complexity of pagination.

LIMIT 1 no longer errors in DBVisualizer, and I added some extra tests for it in our test class.

### Related Issue

closes #69 

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
