### PR TITLE
Incorrect GROUP BY and WHERE results

### DIFF
--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectMulti.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectMulti.java
@@ -203,10 +203,10 @@ public class GremlinSqlSelectMulti extends GremlinSqlSelect {
             graphTraversal = g.E().hasLabel(edgeLabel)
                     .where(__.inV().hasLabel(inVLabel))
                     .where(__.outV().hasLabel(outVLabel));
-            applyHaving(graphTraversal);
             applyGroupBy(graphTraversal, edgeLabel, inVRename, outVRename);
             applySelectValues(graphTraversal);
             applyOrderBy(graphTraversal, edgeLabel, inVRename, outVRename);
+            applyHaving(graphTraversal);
             SqlTraversalEngine.applyAggregateFold(sqlMetadata, graphTraversal);
             graphTraversal.project(inVRename, outVRename);
             applyColumnRetrieval(graphTraversal, inVRename, gremlinSqlNodesIn, StepDirection.In);

--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectMulti.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectMulti.java
@@ -203,10 +203,10 @@ public class GremlinSqlSelectMulti extends GremlinSqlSelect {
             graphTraversal = g.E().hasLabel(edgeLabel)
                     .where(__.inV().hasLabel(inVLabel))
                     .where(__.outV().hasLabel(outVLabel));
+            applyHaving(graphTraversal);
             applyGroupBy(graphTraversal, edgeLabel, inVRename, outVRename);
             applySelectValues(graphTraversal);
             applyOrderBy(graphTraversal, edgeLabel, inVRename, outVRename);
-            applyHaving(graphTraversal);
             SqlTraversalEngine.applyAggregateFold(sqlMetadata, graphTraversal);
             graphTraversal.project(inVRename, outVRename);
             applyColumnRetrieval(graphTraversal, inVRename, gremlinSqlNodesIn, StepDirection.In);

--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectSingle.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectSingle.java
@@ -126,11 +126,11 @@ public class GremlinSqlSelectSingle extends GremlinSqlSelect {
             generateDataRetrieval(gremlinSqlIdentifiers, __.__());
 
             // Generate actual traversal.
-            applyHaving(graphTraversal);
             applyWhere(graphTraversal);
             applyGroupBy(graphTraversal, label);
             applySelectValues(graphTraversal);
             applyOrderBy(graphTraversal, label);
+            applyHaving(graphTraversal);
             generateDataRetrieval(gremlinSqlIdentifiers, graphTraversal);
 
             if (sqlMetadata.getRenamedColumns() == null) {

--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectSingle.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectSingle.java
@@ -126,11 +126,11 @@ public class GremlinSqlSelectSingle extends GremlinSqlSelect {
             generateDataRetrieval(gremlinSqlIdentifiers, __.__());
 
             // Generate actual traversal.
+            applyHaving(graphTraversal);
+            applyWhere(graphTraversal);
             applyGroupBy(graphTraversal, label);
             applySelectValues(graphTraversal);
             applyOrderBy(graphTraversal, label);
-            applyHaving(graphTraversal);
-            applyWhere(graphTraversal);
             generateDataRetrieval(gremlinSqlIdentifiers, graphTraversal);
 
             if (sqlMetadata.getRenamedColumns() == null) {

--- a/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlAggregateTest.java
+++ b/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlAggregateTest.java
@@ -74,4 +74,19 @@ public class GremlinSqlAggregateTest extends GremlinSqlBaseTest {
         // Validate that the output column is COUNT(*) and the value is correct.
         runQueryTestResults("SELECT COUNT(*) FROM person", columns("COUNT(*)"), rows(r(6L)));
     }
+
+    @Test
+    public void testCountWhereGroupBy() throws SQLException {
+        runQueryTestResults("SELECT wentToSpace, COUNT(age) FROM person WHERE age > 30 GROUP BY wentToSpace",
+                columns("wentToSpace", "COUNT(age)"), rows(r(false, 2L), r(true, 2L)));
+        runQueryTestResults("SELECT wentToSpace, COUNT(age) FROM person WHERE age > 50 GROUP BY wentToSpace",
+                columns("wentToSpace", "COUNT(age)"), rows());
+        runQueryTestResults("SELECT wentToSpace, COUNT(age) FROM person WHERE age > 0 GROUP BY wentToSpace",
+                columns("wentToSpace", "COUNT(age)"), rows(r(false, 3L), r(true, 3L)));
+        runQueryTestResults("SELECT wentToSpace, COUNT(age) FROM person WHERE age < 100 AND wentToSpace = FALSE GROUP BY wentToSpace",
+                columns("wentToSpace", "COUNT(age)"), rows(r(false, 3L)));
+        runQueryTestResults("SELECT wentToSpace, COUNT(age) FROM person WHERE age > 31 AND wentToSpace = FALSE GROUP BY wentToSpace",
+                columns("wentToSpace", "COUNT(age)"), rows(r(false, 1L)));
+
+    }
 }


### PR DESCRIPTION
### Summary

Incorrect GROUP BY and WHERE results

### Description

The issue is due to the way the data stream in the traversal gets modified if a group by is imposed before the where. 

A detailed explanation of offending queries and result examples is provided in #75 

To fix the issue, I switched the order of GROUP BY and WHERE such that WHERE is imposed before GROUP BY. This makes more sense since it will cause filtering to be imposed before grouping. Filtering does not change the data stream of the query but grouping does.

### Related Issue

fixes #75 

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
