### PR TITLE
Fix a couple of copy-paste typos in edge selection

### DIFF
--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/SqlTraversalEngine.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/SqlTraversalEngine.java
@@ -144,7 +144,7 @@ public class SqlTraversalEngine {
             }
         } else {
             // It's this vertex/edge.
-            if (columnName.toLowerCase(Locale.getDefault()).startsWith(gremlinTableBase.getLabel())) {
+            if (columnName.toLowerCase(Locale.getDefault()).startsWith(gremlinTableBase.getLabel().toLowerCase(Locale.getDefault()))) {
                 graphTraversal.id();
             } else {
                 if (columnName.endsWith(IN_ID)) {
@@ -162,7 +162,7 @@ public class SqlTraversalEngine {
                         graphTraversal.coalesce(__.outE().hasLabel(columnName.replace(OUT_ID, "")).id().fold(),
                                 __.constant(new ArrayList<>()));
                     } else {
-                        graphTraversal.coalesce(__.outV().hasLabel(columnName.replace(IN_ID, "")).id(),
+                        graphTraversal.coalesce(__.outV().hasLabel(columnName.replace(OUT_ID, "")).id(),
                                 __.constant(new ArrayList<>()));
                     }
                 } else {

--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/schema/gremlin/GremlinEdgeTable.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/schema/gremlin/GremlinEdgeTable.java
@@ -55,7 +55,7 @@ public class GremlinEdgeTable extends GremlinTableBase {
             final GremlinProperty inFk = new GremlinProperty(inOutPair.getKey() + GremlinTableBase.IN_ID, "string");
             final GremlinProperty outFk = new GremlinProperty(inOutPair.getValue() + GremlinTableBase.OUT_ID, "string");
             columnsWithPKFK.put(inFk.getName(), inFk);
-            columnsWithPKFK.put(outFk.getName(), inFk);
+            columnsWithPKFK.put(outFk.getName(), outFk);
         });
         return columnsWithPKFK;
     }

--- a/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlAdvancedSelectTest.java
+++ b/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlAdvancedSelectTest.java
@@ -45,6 +45,12 @@ public class GremlinSqlAdvancedSelectTest extends GremlinSqlBaseTest {
     }
 
     @Test
+    public void testEdges() throws SQLException {
+        runQueryTestResults("select * from worksFor where yearsWorked = 9", columns("person_OUT_ID", "company_IN_ID", "yearsWorked", "worksFor_ID"),
+                rows(r(26L, 2L, 9, 64L)));
+    }
+
+    @Test
     public void testOrder() throws SQLException {
         // ORDER with integer column.
         runQueryTestResults("SELECT name, age FROM person ORDER BY age", columns("name", "age"),


### PR DESCRIPTION

### Summary

Fix a couple of copy-paste typos in edge selection

1. add test: select * from edgeLabel
2. Fix 2 typos: IN_ID -> OUT_ID
3. Lowcase label name to compare with table name

### Description

<!--- Details of what you changed -->

### Related Issue

<!--- Link to issue where this is tracked -->

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
