### PR TITLE
Update Log4J to 2.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -278,7 +278,7 @@ repositories {
 
 ext {
     calciteVersion = '1.28.0'
-    log4jVersion = '2.13.3'
+    log4jVersion = '2.15.0'
     lombokVersion = '1.18.16'
     jupiterVersion = '5.4.0'
     neo4jDBVersion = '3.5.19'


### PR DESCRIPTION
### Summary
Update Log4J dependency based on the advisory (Remote code injection in Log4j) - https://github.com/advisories/GHSA-jfh8-c2jp-5v3q

### Description
Log4J library updated from 2.13 to 2.15.0 to resolve critical vulnerability

### Related Issue
https://github.com/advisories/GHSA-jfh8-c2jp-5v3q

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
