### PR TITLE
Ensure metadata cache doesn't apply to wrong connections

### DIFF
--- a/src/main/java/software/aws/neptune/gremlin/GremlinQueryExecutor.java
+++ b/src/main/java/software/aws/neptune/gremlin/GremlinQueryExecutor.java
@@ -300,7 +300,8 @@ public class GremlinQueryExecutor extends QueryExecutor {
     public java.sql.ResultSet executeGetTables(final java.sql.Statement statement, final String tableName)
             throws SQLException {
         LOGGER.info("GremlinQueryExecutor executeGetTables");
-        if (!MetadataCache.isMetadataCached()) {
+        final String endpoint = this.gremlinConnectionProperties.getContactPoint();
+        if (!MetadataCache.isMetadataCached(endpoint)) {
             // TODO AN-576: Temp isValid check. Find a better solution inside the export tool to check if connection is valid.
             if (!statement.getConnection().isValid(3000)) {
                 throw new SQLException("Failed to execute getTables, could not connect to database.");
@@ -308,8 +309,8 @@ public class GremlinQueryExecutor extends QueryExecutor {
         }
         MetadataCache.updateCacheIfNotUpdated(gremlinConnectionProperties);
         return new GremlinResultSetGetTables(statement,
-                MetadataCache.getFilteredCacheNodeColumnInfos(tableName),
-                MetadataCache.getFilteredResultSetInfoWithoutRowsForTables(tableName));
+                MetadataCache.getFilteredCacheNodeColumnInfos(tableName, endpoint),
+                MetadataCache.getFilteredResultSetInfoWithoutRowsForTables(tableName, endpoint));
     }
 
     /**
@@ -361,7 +362,8 @@ public class GremlinQueryExecutor extends QueryExecutor {
     public java.sql.ResultSet executeGetColumns(final java.sql.Statement statement, final String nodes)
             throws SQLException {
         LOGGER.info("GremlinQueryExecutor executeGetColumns");
-        if (!MetadataCache.isMetadataCached()) {
+        final String endpoint = this.gremlinConnectionProperties.getContactPoint();
+        if (!MetadataCache.isMetadataCached(endpoint)) {
             // TODO AN-576: Temp isValid check. Find a better solution inside the export tool to check if connection is valid.
             if (!statement.getConnection().isValid(3000)) {
                 throw new SQLException("Failed to execute getTables, could not connect to database.");
@@ -369,8 +371,8 @@ public class GremlinQueryExecutor extends QueryExecutor {
         }
         MetadataCache.updateCacheIfNotUpdated(gremlinConnectionProperties);
         return new GremlinResultSetGetColumns(statement,
-                MetadataCache.getFilteredCacheNodeColumnInfos(nodes),
-                MetadataCache.getFilteredResultSetInfoWithoutRowsForColumns(nodes));
+                MetadataCache.getFilteredCacheNodeColumnInfos(nodes, endpoint),
+                MetadataCache.getFilteredResultSetInfoWithoutRowsForColumns(nodes, endpoint));
     }
 
     /**

--- a/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinQueryExecutor.java
+++ b/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinQueryExecutor.java
@@ -91,7 +91,8 @@ public class SqlGremlinQueryExecutor extends GremlinQueryExecutor {
             throws SQLException {
         MetadataCache.updateCacheIfNotUpdated(gremlinConnectionProperties);
         if (gremlinSqlConverter == null) {
-            gremlinSqlConverter = new SqlConverter(MetadataCache.getGremlinSchema());
+            gremlinSqlConverter = new SqlConverter(MetadataCache.getGremlinSchema(
+                    gremlinConnectionProperties.getContactPoint()));
         }
         return gremlinSqlConverter;
     }
@@ -107,14 +108,15 @@ public class SqlGremlinQueryExecutor extends GremlinQueryExecutor {
     public java.sql.ResultSet executeGetColumns(final java.sql.Statement statement, final String nodes)
             throws SQLException {
         LOGGER.info("Running executeGetColumns.");
-        if (!MetadataCache.isMetadataCached()) {
+        final String endpoint = this.gremlinConnectionProperties.getContactPoint();
+        if (!MetadataCache.isMetadataCached(endpoint)) {
             if (!statement.getConnection().isValid(3000)) {
                 throw new SQLException("Failed to execute getTables, could not connect to database.");
             }
         }
         MetadataCache.updateCacheIfNotUpdated(gremlinConnectionProperties);
-        return new GremlinResultSetGetColumns(statement, MetadataCache.getFilteredCacheNodeColumnInfos(nodes),
-                MetadataCache.getFilteredResultSetInfoWithoutRowsForColumns(nodes));
+        return new GremlinResultSetGetColumns(statement, MetadataCache.getFilteredCacheNodeColumnInfos(nodes, endpoint),
+                MetadataCache.getFilteredResultSetInfoWithoutRowsForColumns(nodes, endpoint));
     }
 
     /**
@@ -129,14 +131,16 @@ public class SqlGremlinQueryExecutor extends GremlinQueryExecutor {
     public java.sql.ResultSet executeGetTables(final java.sql.Statement statement, final String tableName)
             throws SQLException {
         LOGGER.info("Running executeGetTables.");
-        if (!MetadataCache.isMetadataCached()) {
+        final String endpoint = this.gremlinConnectionProperties.getContactPoint();
+        if (!MetadataCache.isMetadataCached(endpoint)) {
             if (!statement.getConnection().isValid(3000)) {
                 throw new SQLException("Failed to execute getTables, could not connect to database.");
             }
         }
         MetadataCache.updateCacheIfNotUpdated(gremlinConnectionProperties);
-        return new GremlinResultSetGetTables(statement, MetadataCache.getFilteredCacheNodeColumnInfos(tableName),
-                MetadataCache.getFilteredResultSetInfoWithoutRowsForTables(tableName));
+        return new GremlinResultSetGetTables(statement,
+                MetadataCache.getFilteredCacheNodeColumnInfos(tableName, endpoint),
+                MetadataCache.getFilteredResultSetInfoWithoutRowsForTables(tableName, endpoint));
     }
 
     /**

--- a/src/main/java/software/aws/neptune/jdbc/DatabaseMetaData.java
+++ b/src/main/java/software/aws/neptune/jdbc/DatabaseMetaData.java
@@ -18,6 +18,7 @@ package software.aws.neptune.jdbc;
 
 import org.slf4j.LoggerFactory;
 import software.aws.neptune.common.EmptyResultSet;
+import software.aws.neptune.gremlin.GremlinConnectionProperties;
 import software.aws.neptune.jdbc.utilities.CastHelper;
 import software.aws.neptune.jdbc.utilities.SqlError;
 import java.io.PrintWriter;
@@ -777,7 +778,7 @@ public abstract class DatabaseMetaData implements java.sql.DatabaseMetaData {
     @Override
     public String getURL() throws SQLException {
         // "contactPoint" is the property key for the hostname for the connection
-        return this.connection.getClientInfo("contactPoint");
+        return this.connection.getClientInfo(GremlinConnectionProperties.CONTACT_POINT_KEY);
     }
 
     @Override

--- a/src/main/java/software/aws/neptune/opencypher/OpenCypherQueryExecutor.java
+++ b/src/main/java/software/aws/neptune/opencypher/OpenCypherQueryExecutor.java
@@ -182,9 +182,11 @@ public class OpenCypherQueryExecutor extends QueryExecutor {
     @Override
     public java.sql.ResultSet executeGetTables(final java.sql.Statement statement, final String tableName)
             throws SQLException {
+        final String endpoint = this.openCypherConnectionProperties.getEndpoint();
         MetadataCache.updateCacheIfNotUpdated(openCypherConnectionProperties);
-        return new OpenCypherResultSetGetTables(statement, MetadataCache.getFilteredCacheNodeColumnInfos(tableName),
-                MetadataCache.getFilteredResultSetInfoWithoutRowsForTables(tableName));
+        return new OpenCypherResultSetGetTables(statement,
+                MetadataCache.getFilteredCacheNodeColumnInfos(tableName, endpoint),
+                MetadataCache.getFilteredResultSetInfoWithoutRowsForTables(tableName, endpoint));
     }
 
     /**
@@ -232,9 +234,11 @@ public class OpenCypherQueryExecutor extends QueryExecutor {
     @Override
     public java.sql.ResultSet executeGetColumns(final java.sql.Statement statement, final String nodes)
             throws SQLException {
+        final String endpoint = this.openCypherConnectionProperties.getEndpoint();
         MetadataCache.updateCacheIfNotUpdated(openCypherConnectionProperties);
-        return new OpenCypherResultSetGetColumns(statement, MetadataCache.getFilteredCacheNodeColumnInfos(nodes),
-                MetadataCache.getFilteredResultSetInfoWithoutRowsForColumns(nodes));
+        return new OpenCypherResultSetGetColumns(statement,
+                MetadataCache.getFilteredCacheNodeColumnInfos(nodes, endpoint),
+                MetadataCache.getFilteredResultSetInfoWithoutRowsForColumns(nodes, endpoint));
     }
 
     /**


### PR DESCRIPTION
### Summary

Ensure metadata cache doesn't apply to wrong connections

### Description

Stored the metadata cache in a map with the host has the key

### Related Issue

https://bitquill.atlassian.net/browse/AN-921

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
