### PR TITLE
Updating log4j dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -278,7 +278,7 @@ repositories {
 
 ext {
     calciteVersion = '1.28.0'
-    log4jVersion = '2.15.0'
+    log4jVersion = '2.16.0'
     lombokVersion = '1.18.16'
     jupiterVersion = '5.4.0'
     neo4jDBVersion = '3.5.19'


### PR DESCRIPTION
CVE-2021-45046

### Summary
CVE-2021-45046

### Description
Updating dependency due to CVE-2021-45046 to 2.16.0

### Related Issue
N/A

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
