### PR TITLE
Fix for false positive exception on statement shutdown

### DIFF
--- a/src/main/java/software/aws/neptune/jdbc/Statement.java
+++ b/src/main/java/software/aws/neptune/jdbc/Statement.java
@@ -67,7 +67,7 @@ public class Statement implements java.sql.Statement {
     @Override
     public void cancel() throws SQLException {
         verifyOpen();
-        queryExecutor.cancelQuery();
+        queryExecutor.cancelQuery(false);
     }
 
     @Override
@@ -87,8 +87,7 @@ public class Statement implements java.sql.Statement {
         if (!this.isClosed.getAndSet(true)) {
             LOGGER.debug("Cancelling running queries.");
             try {
-                // TODO: Only cancel if query currently in progress?
-                queryExecutor.cancelQuery();
+                queryExecutor.cancelQuery(true);
             } catch (final SQLException e) {
                 LOGGER.warn("Error occurred while closing Statement. Failed to cancel running query: '"
                         + e.getMessage() + "'");

--- a/src/main/java/software/aws/neptune/jdbc/utilities/QueryExecutor.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/QueryExecutor.java
@@ -198,12 +198,6 @@ public abstract class QueryExecutor {
             }
         }
     }
-    //
-    //  project("country","region","elev","elev","elev","elev","lat","lat","lat","lat")
-    //      .choose(__.has("country"),__.values("country"),__.constant(""))
-    //      .choose(__.has("region"),__.values("region"),__.constant(""))
-    // Sub traversal:
-    //      unfold().choose(__.has("elev"),__.values("elev"),__.constant(""))
 
     private void resetQueryState() {
         queryState = QueryState.NOT_STARTED;
@@ -217,9 +211,12 @@ public abstract class QueryExecutor {
      *
      * @throws SQLException if query cancellation fails.
      */
-    public void cancelQuery() throws SQLException {
+    public void cancelQuery(final boolean isClosing) throws SQLException {
         synchronized (lock) {
             if (queryState.equals(QueryState.NOT_STARTED)) {
+                if (isClosing) {
+                    return;
+                }
                 throw SqlError.createSQLException(
                         LOGGER,
                         SqlState.OPERATION_CANCELED,


### PR DESCRIPTION
### Summary

Fix for false positive exception on shutdown

### Description

Query executor spits out an exception log when statement is closed. This is because it doesn't realize that close is just doing a final check to cancel any pending queries. This fixes that false positive exception.
[1] Fixed false positive issue for query executor

### Related Issue

closes #108 

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
