### PR TITLE
pass optional connection properties to sql SchemaHelper (#116)

### DIFF
--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/MetadataCache.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/MetadataCache.java
@@ -70,6 +70,21 @@ public class MetadataCache {
 
     /**
      * Function to update the cache of the metadata.
+     * @param gremlinConnectionProperties GremlinConnectionProperties to use.
+     * @throws SQLException
+     */
+    public static void updateGremlinCache(final GremlinConnectionProperties gremlinConnectionProperties)
+            throws SQLException {
+        String endpoint = gremlinConnectionProperties.getContactPoint();
+        synchronized (LOCK) {
+            if (!GREMLIN_SCHEMAS.containsKey(endpoint)) {
+                GREMLIN_SCHEMAS.put(endpoint, SchemaHelperGremlinDataModel.getGremlinGraphSchema(gremlinConnectionProperties));
+            }
+        }
+    }
+
+    /**
+     * Function to update the cache of the metadata.
      *
      * @param gremlinConnectionProperties GremlinConnectionProperties to use.
      * @throws SQLException Thrown if error occurs during update.
@@ -77,12 +92,10 @@ public class MetadataCache {
     public static void updateCacheIfNotUpdated(final GremlinConnectionProperties gremlinConnectionProperties)
             throws SQLException {
         if (!isMetadataCached(gremlinConnectionProperties.getContactPoint())) {
-            updateCache(gremlinConnectionProperties.getContactPoint(), gremlinConnectionProperties.getPort(),
-                    (gremlinConnectionProperties.getAuthScheme() == AuthScheme.IAMSigV4),
-                    gremlinConnectionProperties.getEnableSsl(),
-                    MetadataCache.PathType.Gremlin, gremlinConnectionProperties.getScanType());
+            updateGremlinCache(gremlinConnectionProperties);
         }
     }
+
 
     /**
      * Function to update the cache of the metadata.

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/MetadataCache.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/MetadataCache.java
@@ -75,7 +75,7 @@ public class MetadataCache {
      */
     public static void updateGremlinCache(final GremlinConnectionProperties gremlinConnectionProperties)
             throws SQLException {
-        String endpoint = gremlinConnectionProperties.getContactPoint();
+        final String endpoint = gremlinConnectionProperties.getContactPoint();
         synchronized (LOCK) {
             if (!GREMLIN_SCHEMAS.containsKey(endpoint)) {
                 GREMLIN_SCHEMAS.put(endpoint, SchemaHelperGremlinDataModel.getGremlinGraphSchema(gremlinConnectionProperties));

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/SchemaHelperGremlinDataModel.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/SchemaHelperGremlinDataModel.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.twilmes.sql.gremlin.adapter.converter.schema.SqlSchemaGrabber;
 import org.twilmes.sql.gremlin.adapter.converter.schema.calcite.GremlinSchema;
+import software.aws.neptune.gremlin.GremlinConnectionProperties;
+import software.aws.neptune.gremlin.GremlinQueryExecutor;
 import software.aws.neptune.jdbc.utilities.SqlError;
 import software.aws.neptune.jdbc.utilities.SqlState;
 import java.sql.SQLException;
@@ -88,5 +90,19 @@ public class SchemaHelperGremlinDataModel {
         return SqlSchemaGrabber.getSchema(
                 traversal().withRemote(DriverRemoteConnection.using(getClient(adjustedEndpoint, port, useIAM, useSsl))),
                 scanType);
+    }
+
+    /**
+     * Function to get the schema of the graph through gremlin connection
+     *
+     * @param gremlinConnectionProperties connection parameters
+     * @return
+     * @throws SQLException
+     */
+    public static GremlinSchema getGremlinGraphSchema(final GremlinConnectionProperties gremlinConnectionProperties)
+            throws SQLException {
+        return SqlSchemaGrabber.getSchema(
+                traversal().withRemote(DriverRemoteConnection.using(GremlinQueryExecutor.getClient(gremlinConnectionProperties))),
+                gremlinConnectionProperties.getScanType());
     }
 }

--- a/src/main/java/software/aws/neptune/gremlin/GremlinQueryExecutor.java
+++ b/src/main/java/software/aws/neptune/gremlin/GremlinQueryExecutor.java
@@ -94,7 +94,7 @@ public class GremlinQueryExecutor extends QueryExecutor {
                 builder.serializer(properties.getSerializerObject());
             } else if (properties.isSerializerEnum()) {
                 builder.serializer(properties.getSerializerEnum());
-            } else if (properties.isChannelizerString()) {
+            } else if (properties.isSerializerString()) {
                 builder.serializer(properties.getSerializerString());
             }
         }
@@ -214,7 +214,7 @@ public class GremlinQueryExecutor extends QueryExecutor {
         }
     }
 
-    protected static Client getClient(final GremlinConnectionProperties gremlinConnectionProperties)
+    public static Client getClient(final GremlinConnectionProperties gremlinConnectionProperties)
             throws SQLException {
         synchronized (CLUSTER_LOCK) {
             cluster = getCluster(gremlinConnectionProperties);


### PR DESCRIPTION
### Summary

SchemaHelperGremlinDataModel was  updated to accept GremlinConnectionProperties from base connection. This also allows the schema helper to use cached connections. Was there any reason to have a separate connection here?

<!--- General summary / title -->

### Description

<!--- Details of what you changed -->

### Related Issue

#116 

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
