### PR TITLE
Add slf4j library to the uber jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -400,8 +400,4 @@ shadowJar {
     relocate 'com.jcraft', 'shadow.com.jcraft'
     relocate 'com.squareup', 'shadow.com.squareup'
     relocate 'com.yahoo', 'shadow.com.yahoo'
-
-    dependencies {
-        exclude(dependency('org.slf4j:.*'))
-    }
 }


### PR DESCRIPTION
Some BI tools may require all dependencies in the uber jar, the absence of the slf4j library may prevent the driver to be operational in some BI tools.

### Summary
Removed slf4j exclusion in the uber jar file

### Description
Changes are tested with Tableau Desktop, DBVisualizer, Aqua Data Studio and IntelliJ Idea.

Without this change, the driver can not be loaded in IntelliJ Idea.

### Related Issue
N/A

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
