### PR TITLE
Update Log4j to 2.17.1 to address CVE-2021-44832

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -278,7 +278,7 @@ repositories {
 
 ext {
     calciteVersion = '1.28.0'
-    log4jVersion = '2.16.0'
+    log4jVersion = '2.17.1'
     lombokVersion = '1.18.16'
     jupiterVersion = '5.4.0'
     neo4jDBVersion = '3.5.19'


### PR DESCRIPTION
### Summary

https://nvd.nist.gov/vuln/detail/CVE-2021-44832

### Description

Updating Log4j version to 2.17.1 because of CVE-2021-44832 vulnerability.
https://nvd.nist.gov/vuln/detail/CVE-2021-44832

### Related Issue

N/A

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
