### PR TITLE
feat: Add support for scalar values without column names

### DIFF
--- a/src/main/java/software/aws/neptune/gremlin/GremlinQueryExecutor.java
+++ b/src/main/java/software/aws/neptune/gremlin/GremlinQueryExecutor.java
@@ -465,7 +465,7 @@ public class GremlinQueryExecutor extends QueryExecutor {
     }
 
     @NotNull
-    protected String generateColumnKey(Long unnamedColumnIndex) {
+    protected String generateColumnKey(final Long unnamedColumnIndex) {
         return String.format("_col%d", unnamedColumnIndex);
     }
 

--- a/src/main/java/software/aws/neptune/gremlin/GremlinQueryExecutor.java
+++ b/src/main/java/software/aws/neptune/gremlin/GremlinQueryExecutor.java
@@ -21,6 +21,7 @@ import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.Result;
 import org.apache.tinkerpop.gremlin.driver.SigV4WebSocketChannelizer;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.aws.neptune.common.gremlindatamodel.MetadataCache;
@@ -401,41 +402,71 @@ public class GremlinQueryExecutor extends QueryExecutor {
         final List<Result> results = completableFuture.get().all().get();
         final List<Map<String, Object>> rows = new ArrayList<>();
         final Map<String, Class<?>> columns = new HashMap<>();
+        Long unnamedColumnIndex = 0L;
         for (final Object result : results.stream().map(Result::getObject).collect(Collectors.toList())) {
-            if (!(result instanceof LinkedHashMap)) {
-                // Best way to handle it seems to be to issue a warning.
-                LOGGER.warn(String.format("Result of type '%s' is not convertible to a Map and will be skipped.",
-                        result.getClass().getCanonicalName()));
-                continue;
-            }
+            if (result instanceof LinkedHashMap) {
+                // We don't know key or value types, so pull it out raw.
+                final Map<?, ?> uncastedRow = (LinkedHashMap<?, ?>) result;
 
-            // We don't know key or value types, so pull it out raw.
-            final Map<?, ?> uncastedRow = (LinkedHashMap<?, ?>) result;
+                // Convert generic key types to string and insert in new map with corresponding value.
+                final Map<String, Object> row = new HashMap<>();
+                uncastedRow.forEach((key, value) -> row.put(key.toString(), value));
 
-            // Convert generic key types to string and insert in new map with corresponding value.
-            final Map<String, Object> row = new HashMap<>();
-            uncastedRow.forEach((key, value) -> row.put(key.toString(), value));
+                // Add row to List of rows.
+                rows.add(row);
 
-            // Add row to List of rows.
-            rows.add(row);
-
-            // Get columns from row and put in columns List if they aren't already in there.
-            for (final String key : row.keySet()) {
-                if (!columns.containsKey(key)) {
-                    final Object value = row.get(key);
-                    if (GremlinTypeMapping.checkContains(value.getClass())) {
-                        columns.put(key, value.getClass());
-                    } else {
+                // Get columns from row and put in columns List if they aren't already in there.
+                for (final String key : row.keySet()) {
+                    if (!columns.containsKey(key)) {
+                        final Object value = row.get(key);
+                        if (GremlinTypeMapping.checkContains(value.getClass())) {
+                            columns.put(key, value.getClass());
+                        } else {
+                            columns.put(key, String.class);
+                        }
+                    } else if (columns.get(key) != row.get(key)) {
                         columns.put(key, String.class);
                     }
-                } else if (columns.get(key) != row.get(key)) {
-                    columns.put(key, String.class);
                 }
+            } else if (GremlinTypeMapping.checkContains(result.getClass())) {
+                // Result is scalar - generate a new key for the column
+                String key = generateColumnKey(unnamedColumnIndex);
+
+                // While there is a conflict with an existing key increment and regenerate the column key
+                while (columns.containsKey(key)) {
+                    if (unnamedColumnIndex == Long.MAX_VALUE) {
+                        LOGGER.warn(String.format("Reached the maximum number of column keys available for scalar columns: %d",
+                                unnamedColumnIndex));
+                        throw SqlError.createSQLException(
+                                LOGGER,
+                                SqlState.NUMERIC_VALUE_OUT_OF_RANGE,
+                                SqlError.INVALID_MAX_FIELD_SIZE);
+                    }
+                    unnamedColumnIndex++;
+                    key = generateColumnKey(unnamedColumnIndex);
+                }
+                columns.put(key, result.getClass());
+
+                // Create and add new row with generated key
+                final Map<String, Object> row = new HashMap<>();
+                row.put(key, result);
+                rows.add(row);
+
+                unnamedColumnIndex++;
+            } else {
+                // If not a map nor scalar best way to handle it seems to be to issue a warning.
+                LOGGER.warn(String.format("Result of type '%s' is not convertible to a Map or Scalar of supported type and will be skipped.",
+                        result.getClass().getCanonicalName()));
             }
         }
 
         final List<String> listColumns = new ArrayList<>(columns.keySet());
         return (T) new GremlinResultSet.ResultSetInfoWithRows(rows, columns, listColumns);
+    }
+
+    @NotNull
+    protected String generateColumnKey(Long unnamedColumnIndex) {
+        return String.format("_col%d", unnamedColumnIndex);
     }
 
     @Override

--- a/src/test/java/software/aws/neptune/gremlin/resultset/GremlinResultSetTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/resultset/GremlinResultSetTest.java
@@ -153,5 +153,32 @@ class GremlinResultSetTest {
         Assertions.assertThrows(SQLException.class, () -> resultSet.getDouble(col));
         Assertions.assertThrows(SQLException.class, () -> resultSet.getFloat(col));
     }
+
+    @Test
+    void testScalarResult() throws SQLException {
+        GremlinResultSet scalarResultSet = (GremlinResultSet) connection.createStatement()
+                .executeQuery("g.V().count()");
+        Assertions.assertNotNull(scalarResultSet);
+        Assertions.assertDoesNotThrow(scalarResultSet::next);
+
+        final int col = scalarResultSet.findColumn("_col0");
+        Assertions.assertEquals(1, scalarResultSet.getLong(col));
+    }
+
+    @Test
+    void testMultipleScalarResults() throws SQLException {
+        GremlinResultSet scalarResultSet = (GremlinResultSet) connection.createStatement()
+                .executeQuery(String.format("g.V().hasLabel('%s').properties().key()", VERTEX));
+        Assertions.assertNotNull(scalarResultSet);
+        int unnamedColumnsFound = 0;
+
+        while (scalarResultSet.next()) {
+            final int col = scalarResultSet.findColumn("_col" + unnamedColumnsFound);
+            Assertions.assertTrue(VERTEX_PROPERTIES_MAP.containsKey(scalarResultSet.getString(col)));
+            unnamedColumnsFound++;
+        }
+
+        Assertions.assertEquals(VERTEX_PROPERTIES_MAP.keySet().size(), unnamedColumnsFound);
+    }
 }
 

--- a/src/test/java/software/aws/neptune/gremlin/resultset/GremlinResultSetTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/resultset/GremlinResultSetTest.java
@@ -156,7 +156,7 @@ class GremlinResultSetTest {
 
     @Test
     void testScalarResult() throws SQLException {
-        GremlinResultSet scalarResultSet = (GremlinResultSet) connection.createStatement()
+        final GremlinResultSet scalarResultSet = (GremlinResultSet) connection.createStatement()
                 .executeQuery("g.V().count()");
         Assertions.assertNotNull(scalarResultSet);
         Assertions.assertDoesNotThrow(scalarResultSet::next);
@@ -167,7 +167,7 @@ class GremlinResultSetTest {
 
     @Test
     void testMultipleScalarResults() throws SQLException {
-        GremlinResultSet scalarResultSet = (GremlinResultSet) connection.createStatement()
+        final GremlinResultSet scalarResultSet = (GremlinResultSet) connection.createStatement()
                 .executeQuery(String.format("g.V().hasLabel('%s').properties().key()", VERTEX));
         Assertions.assertNotNull(scalarResultSet);
         int unnamedColumnsFound = 0;


### PR DESCRIPTION
fixes issue #152

### Summary

Added support for queries that return one or many scalar values. These values will not have a key assigned, acting essentially as columns without name for a JDBC query.

### Description

- Removed condition check that ignores any result that is not of type LinkedHashMap.
- Added handling for scalar types supported by Gremlin (GremlinTypeMapping.checkContains)
- Generated column names in the format `_col0, _col1 ... _colN`

### Related Issue

https://github.com/aws/amazon-neptune-jdbc-driver/issues/152 

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
