### PR TITLE
Fixed bug in getting column names for metadata & edited limitation document

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -330,6 +330,7 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jupiterVersion
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jupiterVersion
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.1.0'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.1.0'
     testImplementation group: 'com.massisframework', name: 'j-text-utils', version: '0.3.4'
     testImplementation group: 'org.neo4j.test', name: 'neo4j-harness', version: neo4jDBVersion
     testImplementation group: 'org.neo4j.community', name: 'it-test-support', version: neo4jDBVersion

--- a/sql-gremlin/README.asciidoc
+++ b/sql-gremlin/README.asciidoc
@@ -104,6 +104,7 @@ Edges and columns also have their own id as a column with the name `<label>_ID`.
 
 == Additional Limitations
 * Currently JDBC driver supports https://www.tableau.com/about/blog/2014/7/understanding-tableau-data-extracts-part1[Tableau Data Extracts (TDE)] and has limitations which may prevent or significantly limit functionality when using Live Connection in Tableau.
+* The driver does not support `Convert to Custom SQL` in Tableau, due to Tableau's use of embedded SQL. If one wishes to issue SQL commands against a live server, https://github.com/aws/amazon-neptune-jdbc-driver/blob/develop/markdown/bi-tools/DbVisualizer.md[DbVisualizer] does provide such functionality.
 
 == Acknowledgements
 Special thanks goes to the http://tinkerpop.incubator.apache.org/[Apache TinkerPop] and https://calcite.apache.org/[Apache Calcite] teams. The depth and breadth of both of these projects is truly astounding. Also, thanks to Daniel Kuppitz. His work on https://github.com/dkuppitz/sparql-gremlin[SPARQL-Gremlin] served as a model and inspiration for SQL-Gremlin.

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/MetadataCache.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/MetadataCache.java
@@ -120,15 +120,15 @@ public class MetadataCache {
     public static GremlinSchema getFilteredCacheNodeColumnInfos(final String nodeFilter, final String endpoint)
             throws SQLException {
         synchronized (LOCK) {
-            if (!GREMLIN_SCHEMAS.containsKey(endpoint)) {
+            if (!getGremlinSchemas().containsKey(endpoint)) {
                 throw new SQLException("Error, cache must be updated before filtered cache can be retrieved.");
             } else if (nodeFilter == null || "%".equals(nodeFilter)) {
-                return GREMLIN_SCHEMAS.get(endpoint);
+                return getGremlinSchemas().get(endpoint);
             }
             LOGGER.info("Getting vertices.");
-            final List<GremlinVertexTable> vertices = GREMLIN_SCHEMAS.get(endpoint).getVertices();
+            final List<GremlinVertexTable> vertices = getGremlinSchemas().get(endpoint).getVertices();
             LOGGER.info("Getting edges.");
-            final List<GremlinEdgeTable> edges = GREMLIN_SCHEMAS.get(endpoint).getEdges();
+            final List<GremlinEdgeTable> edges = getGremlinSchemas().get(endpoint).getEdges();
             final List<GremlinVertexTable> filteredGremlinVertexTables = vertices.stream().filter(
                     table -> Arrays.stream(nodeFilter.split(":")).allMatch(f -> table.getLabel().equals(f)))
                     .collect(Collectors.toList());
@@ -137,6 +137,15 @@ public class MetadataCache {
                     .collect(Collectors.toList());
             return new GremlinSchema(filteredGremlinVertexTables, filteredGremlinEdgeTables);
         }
+    }
+
+    /**
+     * Helper function to get GREMLIN_SCHEMAS.
+     *
+     * @return A map of Gremlin Schemas.
+     */
+    static Map<String, GremlinSchema> getGremlinSchemas() {
+        return GREMLIN_SCHEMAS;
     }
 
     /**

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/MetadataCache.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/MetadataCache.java
@@ -130,10 +130,10 @@ public class MetadataCache {
             LOGGER.info("Getting edges.");
             final List<GremlinEdgeTable> edges = GREMLIN_SCHEMAS.get(endpoint).getEdges();
             final List<GremlinVertexTable> filteredGremlinVertexTables = vertices.stream().filter(
-                    table -> Arrays.stream(nodeFilter.split(":")).allMatch(f -> table.getLabel().contains(f)))
+                    table -> Arrays.stream(nodeFilter.split(":")).allMatch(f -> table.getLabel().equals(f)))
                     .collect(Collectors.toList());
             final List<GremlinEdgeTable> filteredGremlinEdgeTables = edges.stream().filter(
-                    table -> Arrays.stream(nodeFilter.split(":")).allMatch(f -> table.getLabel().contains(f)))
+                    table -> Arrays.stream(nodeFilter.split(":")).allMatch(f -> table.getLabel().equals(f)))
                     .collect(Collectors.toList());
             return new GremlinSchema(filteredGremlinVertexTables, filteredGremlinEdgeTables);
         }

--- a/src/test/java/software/aws/neptune/common/gremlindatamodel/MetadataCacheTest.java
+++ b/src/test/java/software/aws/neptune/common/gremlindatamodel/MetadataCacheTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package software.aws.neptune.common.gremlindatamodel;
+
+import org.apache.calcite.util.Pair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.twilmes.sql.gremlin.adapter.converter.schema.calcite.GremlinSchema;
+import org.twilmes.sql.gremlin.adapter.converter.schema.gremlin.GremlinEdgeTable;
+import org.twilmes.sql.gremlin.adapter.converter.schema.gremlin.GremlinProperty;
+import org.twilmes.sql.gremlin.adapter.converter.schema.gremlin.GremlinVertexTable;
+
+import java.lang.reflect.Method;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MetadataCacheTest {
+    private static final String ENDPOINT = "mockEndpoint";
+
+    @Test
+    void testMetadataCacheFiltering() throws SQLException {
+        // Set up four tables, two vertex table with label "vertex" and "vertexBeta", and two edge tables with labels "edge", "edgeBeta".
+        final GremlinVertexTable testTableVertex = new GremlinVertexTable("vertex",
+                new ArrayList<>(Collections.singletonList(new GremlinProperty("testVertex", "string"))),
+                new ArrayList<>(Collections.singletonList("edgeIn")),
+                new ArrayList<>(Collections.singletonList("edgeOut")));
+        final GremlinVertexTable testTableVertexBeta = new GremlinVertexTable("vertexBeta",
+                new ArrayList<>(Collections.singletonList(new GremlinProperty("testVertex", "string"))),
+                new ArrayList<>(Collections.singletonList("edgeIn")),
+                new ArrayList<>(Collections.singletonList("edgeOut")));
+        final GremlinEdgeTable testTableEdge = new GremlinEdgeTable("edge",
+                new ArrayList<>(Collections.singletonList(new GremlinProperty("testEdge", "string"))),
+                new ArrayList<>(Collections.singletonList(new Pair<>("vertexIn", "vertexOut"))));
+        final GremlinEdgeTable testTableEdgeBeta = new GremlinEdgeTable("edgeBeta",
+                new ArrayList<>(Collections.singletonList(new GremlinProperty("testEdge", "string"))),
+                new ArrayList<>(Collections.singletonList(new Pair<>("vertexIn", "vertexOut"))));
+
+        // Create a full schema to call the method on.
+        final GremlinSchema testFullSchema = new GremlinSchema(new ArrayList<>(Arrays.asList(testTableVertex, testTableVertexBeta)),
+                new ArrayList<>(Arrays.asList(testTableEdge, testTableEdgeBeta)));
+
+        try (MockedStatic<MetadataCache> mockMetadataCache = Mockito.mockStatic(MetadataCache.class, invocation -> {
+            final Method method = invocation.getMethod();
+            if ("getGremlinSchemas".equals(method.getName())) {
+                return invocation.getMock();
+            } else {
+                return invocation.callRealMethod();
+            }}))
+        {
+            final Map<String, GremlinSchema> schemaMap = new HashMap<>();
+            schemaMap.put(ENDPOINT, testFullSchema);
+            mockMetadataCache.when(MetadataCache::getGremlinSchemas).thenReturn(schemaMap);
+            Assertions.assertEquals(schemaMap, MetadataCache.getGremlinSchemas());
+
+            // Assert that filtering based label only gets the specified table.
+            final GremlinSchema generatedVertexSchema = MetadataCache.getFilteredCacheNodeColumnInfos("vertex", ENDPOINT);
+            Assertions.assertEquals("vertex", generatedVertexSchema.getVertices().get(0).getLabel());
+            Assertions.assertEquals(testTableVertex, generatedVertexSchema.getVertices().get(0));
+            Assertions.assertEquals(1, generatedVertexSchema.getVertices().size());
+            Assertions.assertEquals(0, generatedVertexSchema.getEdges().size());
+
+            final GremlinSchema generatedVertexBetaSchema = MetadataCache.getFilteredCacheNodeColumnInfos("vertexBeta", ENDPOINT);
+            Assertions.assertEquals("vertexBeta", generatedVertexBetaSchema.getVertices().get(0).getLabel());
+            Assertions.assertEquals(testTableVertexBeta, generatedVertexBetaSchema.getVertices().get(0));
+            Assertions.assertEquals(1, generatedVertexBetaSchema.getVertices().size());
+            Assertions.assertEquals(0, generatedVertexBetaSchema.getEdges().size());
+
+            final GremlinSchema generatedEdgeSchema = MetadataCache.getFilteredCacheNodeColumnInfos("edge", ENDPOINT);
+            Assertions.assertEquals("edge", generatedEdgeSchema.getEdges().get(0).getLabel());
+            Assertions.assertEquals(testTableEdge, generatedEdgeSchema.getEdges().get(0));
+            Assertions.assertEquals(0, generatedEdgeSchema.getVertices().size());
+            Assertions.assertEquals(1, generatedEdgeSchema.getEdges().size());
+
+            final GremlinSchema generatedEdgeBetaSchema = MetadataCache.getFilteredCacheNodeColumnInfos("edgeBeta", ENDPOINT);
+            Assertions.assertEquals("edgeBeta", generatedEdgeBetaSchema.getEdges().get(0).getLabel());
+            Assertions.assertEquals(testTableEdgeBeta, generatedEdgeBetaSchema.getEdges().get(0));
+            Assertions.assertEquals(0, generatedEdgeBetaSchema.getVertices().size());
+            Assertions.assertEquals(1, generatedEdgeBetaSchema.getEdges().size());
+        }
+    }
+}

--- a/src/test/java/software/aws/neptune/common/gremlindatamodel/MetadataCacheTest.java
+++ b/src/test/java/software/aws/neptune/common/gremlindatamodel/MetadataCacheTest.java
@@ -19,7 +19,6 @@ package software.aws.neptune.common.gremlindatamodel;
 import org.apache.calcite.util.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.twilmes.sql.gremlin.adapter.converter.schema.calcite.GremlinSchema;
@@ -66,8 +65,8 @@ public class MetadataCacheTest {
                 return invocation.getMock();
             } else {
                 return invocation.callRealMethod();
-            }}))
-        {
+            }
+        })) {
             final Map<String, GremlinSchema> schemaMap = new HashMap<>();
             schemaMap.put(ENDPOINT, testFullSchema);
             mockMetadataCache.when(MetadataCache::getGremlinSchemas).thenReturn(schemaMap);


### PR DESCRIPTION
### Summary

Fixed bug in getting column names for metadata & edited limitation document

### Description

Getting column names from a specific table in `MetadataCache.java` was using a string `contains` logic, which for a table name (e.g. table "ABC") it would grab the columns in all table that contains the given name (e.g., tables "ABC", "ABC1", and "ABC2"). This is problematic when a column not in the desired table is grabbed, which may lead to `Error parsing` with a `CalciteContextException: Column 'y' not found in table 'x'` in BI tools that rely on the received column names to generate queries. Now changed to an equality check with `equals`. 

Added Custom SQL in Tableau to SQL driver limitations. 

### Related Issue

Likely related to the bug reported in #148.

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
