### PR TITLE
Fix GROUP BY with renamed table

### DIFF
--- a/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectMulti.java
+++ b/sql-gremlin/src/main/java/org/twilmes/sql/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectMulti.java
@@ -249,7 +249,8 @@ public class GremlinSqlSelectMulti extends GremlinSqlSelect {
             graphTraversal.group();
             final List<GraphTraversal> byUnion = new ArrayList<>();
             for (final GremlinSqlIdentifier gremlinSqlIdentifier : gremlinSqlIdentifiers) {
-                final String table = sqlMetadata.getRenamedTable(gremlinSqlIdentifier.getName(0));
+                final String renamedTable = gremlinSqlIdentifier.getName(0);
+                final String table = sqlMetadata.getRenamedTable(renamedTable);
                 final String column = sqlMetadata
                         .getActualColumnName(sqlMetadata.getGremlinTable(table), gremlinSqlIdentifier.getName(1));
                 if (column.replace(GremlinTableBase.ID, "").equalsIgnoreCase(edgeLabel)) {
@@ -258,10 +259,10 @@ public class GremlinSqlSelectMulti extends GremlinSqlSelect {
                     // TODO: Grouping edges that are not the edge that the vertex are connected - needs to be implemented.
                     throw SqlGremlinError.create(SqlGremlinError.CANNOT_GROUP_EDGES);
                 } else {
-                    if (inVRename.equals(table)) {
+                    if (inVRename.equals(renamedTable)) {
                         byUnion.add(__.inV().hasLabel(table)
                                 .values(sqlMetadata.getActualColumnName(sqlMetadata.getGremlinTable(table), column)));
-                    } else if (outVRename.equals(table)) {
+                    } else if (outVRename.equals(renamedTable)) {
                         byUnion.add(__.outV().hasLabel(table)
                                 .values(sqlMetadata.getActualColumnName(sqlMetadata.getGremlinTable(table), column)));
                     } else {

--- a/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlJoinTest.java
+++ b/sql-gremlin/src/test/java/org/twilmes/sql/gremlin/adapter/GremlinSqlJoinTest.java
@@ -57,6 +57,18 @@ public class GremlinSqlJoinTest extends GremlinSqlBaseTest {
                         "GROUP BY person1.name",
                 columns("name"),
                 rows(r("Patty"), r("Juanita"), r("Susan"), r("Pavel")));
+
+        runJoinQueryTestResults("SELECT p.name FROM gremlin.person p " +
+                        "INNER JOIN gremlin.person p1 ON (p.friendsWith_OUT_ID = p1.friendsWith_IN_ID) " +
+                        "GROUP BY p.name",
+                columns("name"),
+                rows(r("Tom"), r("Patty"), r("Phil"), r("Susan")));
+
+        runJoinQueryTestResults("SELECT p.name, COUNT(p1.name) FROM gremlin.person p " +
+                        "INNER JOIN gremlin.person p1 ON (p.friendsWith_OUT_ID = p1.friendsWith_IN_ID) " +
+                        "GROUP BY p.name",
+                columns("name", "COUNT(name)"),
+                rows(r("Tom", 1L), r("Patty", 1L), r("Phil", 1L), r("Susan", 1L)));
     }
 
     @Test


### PR DESCRIPTION
### Summary

Broken GROUP BY with renamed table

### Description

Fixed a bug in the code

### Related Issue

#174 

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
