### PR TITLE
Fix issues with openCypher IAM auth signature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -325,6 +325,7 @@ dependencies {
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
 
     // Testing
+    testImplementation group: 'info.picocli', name: 'picocli', version: '4.6.3'
     testImplementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jupiterVersion

--- a/src/main/java/software/aws/neptune/opencypher/OpenCypherQueryExecutor.java
+++ b/src/main/java/software/aws/neptune/opencypher/OpenCypherQueryExecutor.java
@@ -76,7 +76,7 @@ public class OpenCypherQueryExecutor extends QueryExecutor {
         if (openCypherConnectionProperties.getAuthScheme().equals(AuthScheme.IAMSigV4)) {
             LOGGER.info("Creating driver with IAMSigV4 authentication.");
             authToken = OpenCypherIAMRequestGenerator
-                    .getSignedHeader(openCypherConnectionProperties.getEndpoint(),
+                    .createAuthToken(openCypherConnectionProperties.getEndpoint(),
                             openCypherConnectionProperties.getServiceRegion());
         }
         return GraphDatabase.driver(openCypherConnectionProperties.getEndpoint(), authToken, config);

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherIAMRequestGeneratorTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherIAMRequestGeneratorTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package software.aws.neptune.opencypher;
+
+import com.amazonaws.http.HttpMethodName;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.internal.security.InternalAuthToken;
+
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.amazonaws.auth.internal.SignerConstants.AUTHORIZATION;
+import static com.amazonaws.auth.internal.SignerConstants.HOST;
+import static com.amazonaws.auth.internal.SignerConstants.X_AMZ_DATE;
+import static com.amazonaws.auth.internal.SignerConstants.X_AMZ_SECURITY_TOKEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.neo4j.driver.Values.value;
+import static org.neo4j.driver.internal.security.InternalAuthToken.CREDENTIALS_KEY;
+import static org.neo4j.driver.internal.security.InternalAuthToken.PRINCIPAL_KEY;
+import static org.neo4j.driver.internal.security.InternalAuthToken.REALM_KEY;
+import static org.neo4j.driver.internal.security.InternalAuthToken.SCHEME_KEY;
+import static software.aws.neptune.opencypher.OpenCypherIAMRequestGenerator.DUMMY_USERNAME;
+import static software.aws.neptune.opencypher.OpenCypherIAMRequestGenerator.HTTP_METHOD_HDR;
+import static software.aws.neptune.opencypher.OpenCypherIAMRequestGenerator.SERVICE_NAME;
+
+class OpenCypherIAMRequestGeneratorTest {
+    private static final String DUMMY_ACCESS_KEY_ID = "xxx";
+    private static final String DUMMY_SESSION_TOKEN = "zzz";
+
+    @BeforeAll
+    public static void beforeAll() {
+        System.setProperty("aws.accessKeyId", DUMMY_ACCESS_KEY_ID);
+        System.setProperty("aws.secretKey", "yyy");
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        System.clearProperty("aws.accessKeyId");
+        System.clearProperty("aws.secretKey");
+    }
+
+    @AfterEach
+    public void afterEach() {
+        System.clearProperty("aws.sessionToken");
+    }
+
+    @Test
+    public void testCreateAuthToken() {
+        verifyAuthToken(false);
+    }
+
+    @Test
+    public void testCreateAuthTokenWithTempCreds() {
+        System.setProperty("aws.sessionToken", DUMMY_SESSION_TOKEN);
+        verifyAuthToken(true);
+    }
+
+    private void verifyAuthToken(final boolean useTempCreds) {
+        final String url = "bolt://somehost.com:58763";
+        final String region = "us-west-2";
+
+        final AuthToken authToken = OpenCypherIAMRequestGenerator.createAuthToken(url, region);
+        assertTrue(authToken instanceof InternalAuthToken);
+        final Map<String, Value> internalAuthToken = ((InternalAuthToken) authToken).toMap();
+
+        assertEquals(value("basic"), internalAuthToken.get(SCHEME_KEY));
+        assertEquals(value(DUMMY_USERNAME), internalAuthToken.get(PRINCIPAL_KEY));
+
+        assertFalse(internalAuthToken.containsKey(REALM_KEY));
+
+        assertTrue(internalAuthToken.containsKey(CREDENTIALS_KEY));
+        final Value credentialsValue = internalAuthToken.get(CREDENTIALS_KEY);
+        final Type type = new TypeToken<Map<String, String>>() {
+        }.getType();
+        final Map<String, String> credentials = new Gson().fromJson(credentialsValue.asString(), type);
+
+        assertNotNull(credentials.get(X_AMZ_DATE));
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssX");
+        final ZonedDateTime xAmzDate = ZonedDateTime.parse(credentials.get(X_AMZ_DATE), formatter);
+        final ZonedDateTime refDateTime = ZonedDateTime.now(ZoneOffset.UTC);
+        final long dateTimeDiff = Duration.between(xAmzDate, refDateTime).getSeconds();
+        assertTrue(dateTimeDiff >= 0 && dateTimeDiff < 60);
+
+        final URI uri = URI.create(url);
+        assertEquals(String.format("%s:%d", uri.getHost(), uri.getPort()), credentials.get(HOST));
+
+        assertEquals(HttpMethodName.GET.name(), credentials.get(HTTP_METHOD_HDR));
+
+        assertEquals(useTempCreds ? DUMMY_SESSION_TOKEN : null, credentials.get(X_AMZ_SECURITY_TOKEN));
+
+        final String auth = credentials.get(AUTHORIZATION);
+        assertNotNull(auth);
+        assertTrue(auth.startsWith("AWS4-HMAC-SHA256"));
+        final Pattern pattern = Pattern.compile("([^,\\s]+)=([^,\\s]+)");
+        final Matcher matcher = pattern.matcher(auth);
+        final Map<String, String> keyValues = new HashMap<>();
+        while (matcher.find()) {
+            assertEquals(2, matcher.groupCount());
+            final String key = matcher.group(1);
+            final String value = matcher.group(2);
+            keyValues.put(key, value);
+        }
+        assertNotNull(keyValues.get("Signature"));
+
+        assertEquals(
+                String.format(
+                        "%s/%s/%s/%s/aws4_request",
+                        DUMMY_ACCESS_KEY_ID,
+                        DateTimeFormatter.ofPattern("yyyyMMdd").format(refDateTime),
+                        region,
+                        SERVICE_NAME
+                ),
+                keyValues.get("Credential")
+        );
+
+        final String signedHeaders = keyValues.get("SignedHeaders");
+        assertNotNull(signedHeaders);
+        final List<String> headers = Arrays.asList(signedHeaders.split(";"));
+        assertTrue(headers.contains(HOST.toLowerCase()));
+        assertTrue(headers.contains(X_AMZ_DATE.toLowerCase()));
+        assertEquals(useTempCreds, headers.contains(X_AMZ_SECURITY_TOKEN.toLowerCase()));
+    }
+}

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherSignatureVerifier.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherSignatureVerifier.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package software.aws.neptune.opencypher;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+
+/**
+ * This class can be used to make a query to a real Neptune instance using IAM auth.
+ * The query is not supposed to return any result, but if there is a problem with the
+ * signature, an exception will be thrown.
+ * <p>
+ * 1. Run with the parameters --host and --region. If you're using SSH tunneling,
+ *    configure your environment as described in markdown/setup/configuration.md,
+ *    and include parameters --ssh-file and --ssh-host.
+ * 2. Set environment variables AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and if using
+ *    temporary credentials, AWS_SESSION_TOKEN.
+ * <p>
+ * You can run this class without any parameters to see its usage.
+ */
+class OpenCypherSignatureVerifier implements Callable<Integer> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenCypherSignatureVerifier.class);
+
+    @CommandLine.Option(names = {"--host"}, description = "Neptune hostname")
+    private String host;
+    @CommandLine.Option(names = {"--region"}, description = "AWS region for Neptune cluster")
+    private String region;
+    @CommandLine.ArgGroup(exclusive = false, multiplicity = "0..1")
+    private Ssh ssh;
+
+    @Override
+    public Integer call() {
+        final String connString = String.format("jdbc:neptune:opencypher://bolt://%s:8182", host);
+
+        try (Connection connection = DriverManager.getConnection(connString, connectionProperties())) {
+            LOGGER.info("Connection created");
+            final Statement statement = connection.createStatement();
+            LOGGER.info("Statement created");
+            final String query = "match (n) where id(n) = '1' return n.prop";
+            final ResultSet results = statement.executeQuery(query);
+            LOGGER.info("Statement executed");
+            while (results.next()) {
+                LOGGER.info("Start result");
+                final String rd = results.getString(1);
+                LOGGER.info(rd);
+                LOGGER.info("End result");
+            }
+        } catch (Exception e) {
+            return 1;
+        }
+        return 0;
+    }
+
+    private Properties connectionProperties() {
+        final Properties properties = new Properties();
+        properties.put("authScheme", "IAMSigV4");
+        properties.put("serviceRegion", region);
+        properties.put("useEncryption", true);
+        properties.put("LogLevel", "DEBUG");
+
+        if (ssh != null) {
+            properties.put("sshUser", ssh.user);
+            properties.put("sshHost", ssh.host);
+            properties.put("sshPrivateKeyFile", ssh.privateKeyFile);
+        }
+
+        return properties;
+    }
+
+    private static class Ssh {
+        @CommandLine.Option(names = {"--ssh-user"}, required = false, description = "username for the internal SSH tunnel")
+        private String user = "ec2-user";
+        @CommandLine.Option(names = {"--ssh-host"}, description = "host name for the internal SSH tunnel")
+        private String host;
+        @CommandLine.Option(names = {"--ssh-file"}, description = "path to the private key file for the internal SSH tunnel")
+        private String privateKeyFile;
+    }
+
+    public static void main(final String[] args) {
+        final int exitCode = new CommandLine(new OpenCypherSignatureVerifier()).execute(args);
+        System.exit(exitCode);
+    }
+}

--- a/src/test/java/software/aws/performance/implementations/executors/OpenCypherBaselineExecutor.java
+++ b/src/test/java/software/aws/performance/implementations/executors/OpenCypherBaselineExecutor.java
@@ -66,7 +66,7 @@ public class OpenCypherBaselineExecutor extends PerformanceTestExecutor {
         AuthToken authToken = AuthTokens.none();
         if (openCypherConnectionProperties.getAuthScheme().equals(AuthScheme.IAMSigV4)) {
             authToken = OpenCypherIAMRequestGenerator
-                    .getSignedHeader(openCypherConnectionProperties.getEndpoint(),
+                    .createAuthToken(openCypherConnectionProperties.getEndpoint(),
                             openCypherConnectionProperties.getServiceRegion());
         }
         final Driver driver = GraphDatabase.driver(openCypherConnectionProperties.getEndpoint(), authToken,


### PR DESCRIPTION
### Summary

Fix issues with openCypher IAM auth signature.

### Description

1. Update auth token generation to match what is expected by the server in engine release 1.1.1.0. 
2. Add `X-Amz-Security-Token` to support session token.
3. Add unit tests to verify the auth token.

Elaborating on item 1 above:
1. The credentials no longer include `HttpVersion":"HTTP/1.1"`
2. Host: *Before:* `"Host":"bolt://somehost:1234"` *After:* `"Host":"somehost.com:1234"`
    Specifically, we no longer include the protocol in the `Host` header.

### Related Issue

https://github.com/aws/amazon-neptune-jdbc-driver/issues/199
https://github.com/aws/amazon-neptune-jdbc-driver/issues/200

### Additional Reviewers
@beebs-systap
