### PR TITLE
Update openCypher signature for Neptune v1.2.0.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ To connect to Amazon Neptune using the JDBC driver, the Neptune instance must be
 
 This driver is compatible with JDBC 4.2 and requires a minimum of Java 8.
 
+### Compatibility with AWS Neptune
+
+| Engine Release           | Driver Version |
+|--------------------------|----------------|
+| < 1.1.1.0                | 1.1.0          |
+| < 1.2.0.0 and >= 1.1.1.0 | 2.0.0+         |
+| >= 1.2.0.0               | 3.0.0+         |
+
 ### Connection URL and Settings
 
 To set up a connection, the driver requires a JDBC connection URL. The connection URL is generally of the form:

--- a/src/main/java/software/aws/neptune/opencypher/OpenCypherIAMRequestGenerator.java
+++ b/src/main/java/software/aws/neptune/opencypher/OpenCypherIAMRequestGenerator.java
@@ -56,8 +56,7 @@ public class OpenCypherIAMRequestGenerator {
         final Request<Void> request = new DefaultRequest<>(SERVICE_NAME);
         request.setHttpMethod(HttpMethodName.GET);
         request.setEndpoint(URI.create(url));
-        // Comment out the following line if you're using an engine version older than 1.2.0.0
-        // request.setResourcePath("/opencypher");
+        request.setResourcePath("/opencypher");
 
         final AWS4Signer signer = new AWS4Signer();
         signer.setRegionName(region);


### PR DESCRIPTION
### Summary

Update openCypher signature for Neptune v1.2.0.0+

### Description

Fixes https://github.com/aws/amazon-neptune-jdbc-driver/issues/202. 
Set path `/opencypher` in request signature.

### Related Issue

<!--- Link to issue where this is tracked -->

### Additional Reviewers
@birschick-bq
@lyndonb-bq
@xiazcy
@simonz-bq
@alexey-temnikov
@kylepbit
