### PR TITLE
Fix issue-209: Upgrade checkstyle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,6 @@ test {
 }
 
 checkstyle {
-    toolVersion '8.37'
     ignoreFailures = true
 }
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -87,7 +87,7 @@
         </module>
 
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
         </module>
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-
+rootProject.name = 'amazon-neptune-jdbc-driver'


### PR DESCRIPTION
### Summary

Upgrade checkstyle

### Description
Fix one of the problems in issue-209: Removing the hard-coded checkstyle version (thus using the default version in the checkstyle plugin) causes the build to fail.
