### PR TITLE
Remove year from license header

### DIFF
--- a/license-header.txt
+++ b/license-header.txt
@@ -1,4 +1,4 @@
-Copyright <${year}> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License").
 You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/NeptuneDatabaseMetadata.java
+++ b/src/main/java/software/aws/neptune/NeptuneDatabaseMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/NeptuneDriver.java
+++ b/src/main/java/software/aws/neptune/NeptuneDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/EmptyResultSet.java
+++ b/src/main/java/software/aws/neptune/common/EmptyResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/EmptyResultSetMetadata.java
+++ b/src/main/java/software/aws/neptune/common/EmptyResultSetMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/ResultSetInfoWithoutRows.java
+++ b/src/main/java/software/aws/neptune/common/ResultSetInfoWithoutRows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/MetadataCache.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/MetadataCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/SchemaHelperGremlinDataModel.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/SchemaHelperGremlinDataModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/GenericResultSet.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/GenericResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetCatalogs.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetCatalogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetColumns.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetSchemas.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetSchemas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetString.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetTableTypes.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetTableTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetTables.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetTables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetTypeInfo.java
+++ b/src/main/java/software/aws/neptune/common/gremlindatamodel/resultset/ResultSetGetTypeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/GremlinConnection.java
+++ b/src/main/java/software/aws/neptune/gremlin/GremlinConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/GremlinConnectionProperties.java
+++ b/src/main/java/software/aws/neptune/gremlin/GremlinConnectionProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/GremlinDataSource.java
+++ b/src/main/java/software/aws/neptune/gremlin/GremlinDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/GremlinPooledConnection.java
+++ b/src/main/java/software/aws/neptune/gremlin/GremlinPooledConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/GremlinQueryExecutor.java
+++ b/src/main/java/software/aws/neptune/gremlin/GremlinQueryExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/GremlinTypeMapping.java
+++ b/src/main/java/software/aws/neptune/gremlin/GremlinTypeMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/SqlConverter.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/SqlConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/SqlMetadata.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/SqlMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/SqlTraversalEngine.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/SqlTraversalEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/GremlinSqlFactory.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/GremlinSqlFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/GremlinSqlNode.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/GremlinSqlNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operands/GremlinSqlIdentifier.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operands/GremlinSqlIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlAsOperator.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlAsOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlBasicCall.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlBasicCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlOperator.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlPostfixOperator.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlPostfixOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlPrefixOperator.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlPrefixOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlTraversalAppender.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/GremlinSqlTraversalAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/aggregate/GremlinSqlAggFunction.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/aggregate/GremlinSqlAggFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/logic/GremlinSqlBinaryOperator.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/logic/GremlinSqlBinaryOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/logic/GremlinSqlLiteral.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/operator/logic/GremlinSqlLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelect.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectMulti.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectMulti.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectSingle.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/select/GremlinSqlSelectSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/select/StepDirection.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/select/StepDirection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/select/join/GremlinSqlJoinComparison.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/ast/nodes/select/join/GremlinSqlJoinComparison.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  *
  */
+
 package software.aws.neptune.gremlin.adapter.converter.ast.nodes.select.join;
 
 import org.apache.calcite.sql.SqlBasicCall;

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/SqlSchemaGrabber.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/SqlSchemaGrabber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinFilter.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinRel.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinRel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinRules.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinSchema.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinTableScan.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinTableScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinToEnumerableConverter.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinToEnumerableConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinToEnumerableConverterRule.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/calcite/GremlinToEnumerableConverterRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/gremlin/GremlinEdgeTable.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/gremlin/GremlinEdgeTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/gremlin/GremlinProperty.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/gremlin/GremlinProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/gremlin/GremlinTableBase.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/gremlin/GremlinTableBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/gremlin/GremlinVertexTable.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/converter/schema/gremlin/GremlinVertexTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/results/SqlGremlinQueryResult.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/results/SqlGremlinQueryResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/results/pagination/GetRowFromMap.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/results/pagination/GetRowFromMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/results/pagination/JoinDataReader.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/results/pagination/JoinDataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/results/pagination/Pagination.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/results/pagination/Pagination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/results/pagination/SimpleDataReader.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/results/pagination/SimpleDataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/util/SQLNotSupportedException.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/util/SQLNotSupportedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/adapter/util/SqlGremlinError.java
+++ b/src/main/java/software/aws/neptune/gremlin/adapter/util/SqlGremlinError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSet.java
+++ b/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetGetCatalogs.java
+++ b/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetGetCatalogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetGetColumns.java
+++ b/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetGetColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetGetSchemas.java
+++ b/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetGetSchemas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetGetTableTypes.java
+++ b/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetGetTableTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetGetTables.java
+++ b/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetGetTables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetGetTypeInfo.java
+++ b/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetGetTypeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetMetadata.java
+++ b/src/main/java/software/aws/neptune/gremlin/resultset/GremlinResultSetMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinConnection.java
+++ b/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinQueryExecutor.java
+++ b/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinQueryExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinResultSet.java
+++ b/src/main/java/software/aws/neptune/gremlin/sql/SqlGremlinResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/Connection.java
+++ b/src/main/java/software/aws/neptune/jdbc/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/DataSource.java
+++ b/src/main/java/software/aws/neptune/jdbc/DataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/DatabaseMetaData.java
+++ b/src/main/java/software/aws/neptune/jdbc/DatabaseMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/Driver.java
+++ b/src/main/java/software/aws/neptune/jdbc/Driver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/PooledConnection.java
+++ b/src/main/java/software/aws/neptune/jdbc/PooledConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/PreparedStatement.java
+++ b/src/main/java/software/aws/neptune/jdbc/PreparedStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/ResultSet.java
+++ b/src/main/java/software/aws/neptune/jdbc/ResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/ResultSetMetaData.java
+++ b/src/main/java/software/aws/neptune/jdbc/ResultSetMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/Statement.java
+++ b/src/main/java/software/aws/neptune/jdbc/Statement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/utilities/AuthScheme.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/AuthScheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/utilities/CastHelper.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/CastHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/utilities/ConnectionProperties.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/ConnectionProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/utilities/JavaToJdbcTypeConverter.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/JavaToJdbcTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/utilities/JdbcType.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/JdbcType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/utilities/QueryExecutor.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/QueryExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/utilities/SqlError.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/SqlError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/utilities/SqlState.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/SqlState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/utilities/SshTunnel.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/SshTunnel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/jdbc/utilities/Warning.java
+++ b/src/main/java/software/aws/neptune/jdbc/utilities/Warning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/OpenCypherConnection.java
+++ b/src/main/java/software/aws/neptune/opencypher/OpenCypherConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/OpenCypherConnectionProperties.java
+++ b/src/main/java/software/aws/neptune/opencypher/OpenCypherConnectionProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/OpenCypherDataSource.java
+++ b/src/main/java/software/aws/neptune/opencypher/OpenCypherDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/OpenCypherIAMRequestGenerator.java
+++ b/src/main/java/software/aws/neptune/opencypher/OpenCypherIAMRequestGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/OpenCypherPooledConnection.java
+++ b/src/main/java/software/aws/neptune/opencypher/OpenCypherPooledConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/OpenCypherQueryExecutor.java
+++ b/src/main/java/software/aws/neptune/opencypher/OpenCypherQueryExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/OpenCypherTypeMapping.java
+++ b/src/main/java/software/aws/neptune/opencypher/OpenCypherTypeMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSet.java
+++ b/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetGetCatalogs.java
+++ b/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetGetCatalogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetGetColumns.java
+++ b/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetGetColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetGetSchemas.java
+++ b/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetGetSchemas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetGetTableTypes.java
+++ b/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetGetTableTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetGetTables.java
+++ b/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetGetTables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetGetTypeInfo.java
+++ b/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetGetTypeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetMetadata.java
+++ b/src/main/java/software/aws/neptune/opencypher/resultset/OpenCypherResultSetMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/SparqlConnection.java
+++ b/src/main/java/software/aws/neptune/sparql/SparqlConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/SparqlConnectionProperties.java
+++ b/src/main/java/software/aws/neptune/sparql/SparqlConnectionProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/SparqlDataSource.java
+++ b/src/main/java/software/aws/neptune/sparql/SparqlDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/SparqlPooledConnection.java
+++ b/src/main/java/software/aws/neptune/sparql/SparqlPooledConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/SparqlQueryExecutor.java
+++ b/src/main/java/software/aws/neptune/sparql/SparqlQueryExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/SparqlTypeMapping.java
+++ b/src/main/java/software/aws/neptune/sparql/SparqlTypeMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/resultset/SparqlAskResultSet.java
+++ b/src/main/java/software/aws/neptune/sparql/resultset/SparqlAskResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/resultset/SparqlAskResultSetMetadata.java
+++ b/src/main/java/software/aws/neptune/sparql/resultset/SparqlAskResultSetMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSet.java
+++ b/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetGetCatelogs.java
+++ b/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetGetCatelogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetGetColumns.java
+++ b/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetGetColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetGetSchemas.java
+++ b/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetGetSchemas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetGetTableTypes.java
+++ b/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetGetTableTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetGetTables.java
+++ b/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetGetTables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetGetTypeInfo.java
+++ b/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetGetTypeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetMetadata.java
+++ b/src/main/java/software/aws/neptune/sparql/resultset/SparqlResultSetMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/resultset/SparqlSelectResultSet.java
+++ b/src/main/java/software/aws/neptune/sparql/resultset/SparqlSelectResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/aws/neptune/sparql/resultset/SparqlTriplesResultSet.java
+++ b/src/main/java/software/aws/neptune/sparql/resultset/SparqlTriplesResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/sample/applications/AuthenticationExamples.java
+++ b/src/test/java/sample/applications/AuthenticationExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/sample/applications/ConnectionOptionsExamples.java
+++ b/src/test/java/sample/applications/ConnectionOptionsExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/sample/applications/ExampleConfigs.java
+++ b/src/test/java/sample/applications/ExampleConfigs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/sample/applications/MetadataExamples.java
+++ b/src/test/java/sample/applications/MetadataExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/sample/applications/QueryExecutionExamples.java
+++ b/src/test/java/sample/applications/QueryExecutionExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/ConnectionPropertiesTestBase.java
+++ b/src/test/java/software/aws/neptune/ConnectionPropertiesTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/NeptuneDriverTestBase.java
+++ b/src/test/java/software/aws/neptune/NeptuneDriverTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/NeptuneDriverTestNoEncryption.java
+++ b/src/test/java/software/aws/neptune/NeptuneDriverTestNoEncryption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/NeptuneDriverTestWithEncryption.java
+++ b/src/test/java/software/aws/neptune/NeptuneDriverTestWithEncryption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/NeptunePreparedStatementTestHelper.java
+++ b/src/test/java/software/aws/neptune/NeptunePreparedStatementTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/NeptuneStatementTestHelper.java
+++ b/src/test/java/software/aws/neptune/NeptuneStatementTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/NeptuneStatementTestHelperBase.java
+++ b/src/test/java/software/aws/neptune/NeptuneStatementTestHelperBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/common/gremlindatamodel/MetadataCacheTest.java
+++ b/src/test/java/software/aws/neptune/common/gremlindatamodel/MetadataCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/GremlinConnectionPropertiesTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/GremlinConnectionPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/GremlinConnectionTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/GremlinConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/GremlinHelper.java
+++ b/src/test/java/software/aws/neptune/gremlin/GremlinHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/GremlinIntegrationTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/GremlinIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/GremlinManualNeptuneVerificationTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/GremlinManualNeptuneVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/GremlinPreparedStatementTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/GremlinPreparedStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/GremlinStatementTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/GremlinStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/GremlinStatementTestBase.java
+++ b/src/test/java/software/aws/neptune/gremlin/GremlinStatementTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlAdvancedSelectTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlAdvancedSelectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlAggregateTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlAggregateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlBaseTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlBasicSelectTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlBasicSelectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlIncompleteSelectTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlIncompleteSelectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlJoinTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlJoinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlNotSupportedTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/GremlinSqlNotSupportedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/graphs/DataTypeGraph.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/graphs/DataTypeGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/graphs/GraphConstants.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/graphs/GraphConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/graphs/SpaceTestGraph.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/graphs/SpaceTestGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/graphs/SpaceTestIncompleteGraph.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/graphs/SpaceTestIncompleteGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/graphs/TestGraph.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/graphs/TestGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/adapter/graphs/TestGraphFactory.java
+++ b/src/test/java/software/aws/neptune/gremlin/adapter/graphs/TestGraphFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/mock/MockGremlinDatabase.java
+++ b/src/test/java/software/aws/neptune/gremlin/mock/MockGremlinDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/resultset/GremlinResultSetTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/resultset/GremlinResultSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/gremlin/sql/SqlGremlinTest.java
+++ b/src/test/java/software/aws/neptune/gremlin/sql/SqlGremlinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/ConnectionTest.java
+++ b/src/test/java/software/aws/neptune/jdbc/ConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/DataSourceTest.java
+++ b/src/test/java/software/aws/neptune/jdbc/DataSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/DatabaseMetaDataTest.java
+++ b/src/test/java/software/aws/neptune/jdbc/DatabaseMetaDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/PooledConnectionTest.java
+++ b/src/test/java/software/aws/neptune/jdbc/PooledConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/PreparedStatementTest.java
+++ b/src/test/java/software/aws/neptune/jdbc/PreparedStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/ResultSetMetaDataTest.java
+++ b/src/test/java/software/aws/neptune/jdbc/ResultSetMetaDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/ResultSetTest.java
+++ b/src/test/java/software/aws/neptune/jdbc/ResultSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/StatementTest.java
+++ b/src/test/java/software/aws/neptune/jdbc/StatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/helpers/HelperFunctions.java
+++ b/src/test/java/software/aws/neptune/jdbc/helpers/HelperFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/mock/MockConnection.java
+++ b/src/test/java/software/aws/neptune/jdbc/mock/MockConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/mock/MockDataSource.java
+++ b/src/test/java/software/aws/neptune/jdbc/mock/MockDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/mock/MockDatabaseMetadata.java
+++ b/src/test/java/software/aws/neptune/jdbc/mock/MockDatabaseMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/mock/MockDriver.java
+++ b/src/test/java/software/aws/neptune/jdbc/mock/MockDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/mock/MockPooledConnection.java
+++ b/src/test/java/software/aws/neptune/jdbc/mock/MockPooledConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/mock/MockPreparedStatement.java
+++ b/src/test/java/software/aws/neptune/jdbc/mock/MockPreparedStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/mock/MockQueryExecutor.java
+++ b/src/test/java/software/aws/neptune/jdbc/mock/MockQueryExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/mock/MockResultSet.java
+++ b/src/test/java/software/aws/neptune/jdbc/mock/MockResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/mock/MockResultSetMetaData.java
+++ b/src/test/java/software/aws/neptune/jdbc/mock/MockResultSetMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/jdbc/mock/MockStatement.java
+++ b/src/test/java/software/aws/neptune/jdbc/mock/MockStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherConnectionPropertiesTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherConnectionPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherConnectionTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherDataSourceTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherDataSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherDatabaseMetadataTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherDatabaseMetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherIAMRequestGeneratorTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherIAMRequestGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherManualIAMTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherManualIAMTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherManualNeptuneVerificationTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherManualNeptuneVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherPreparedStatementTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherPreparedStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherResultSetGetColumnsTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherResultSetGetColumnsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherResultSetMetadataTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherResultSetMetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherResultSetTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherResultSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherSignatureVerifier.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherSignatureVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherStatementTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherStatementTestBase.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherStatementTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/mock/MockOpenCypherDatabase.java
+++ b/src/test/java/software/aws/neptune/opencypher/mock/MockOpenCypherDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/mock/MockOpenCypherNode.java
+++ b/src/test/java/software/aws/neptune/opencypher/mock/MockOpenCypherNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/mock/MockOpenCypherNodes.java
+++ b/src/test/java/software/aws/neptune/opencypher/mock/MockOpenCypherNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/mock/OpenCypherQueryLiterals.java
+++ b/src/test/java/software/aws/neptune/opencypher/mock/OpenCypherQueryLiterals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/opencypher/utilities/OpenCypherGetColumnUtilities.java
+++ b/src/test/java/software/aws/neptune/opencypher/utilities/OpenCypherGetColumnUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/sparql/SparqlConnectionPropertiesTest.java
+++ b/src/test/java/software/aws/neptune/sparql/SparqlConnectionPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/sparql/SparqlConnectionTest.java
+++ b/src/test/java/software/aws/neptune/sparql/SparqlConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/sparql/SparqlDataSourceTest.java
+++ b/src/test/java/software/aws/neptune/sparql/SparqlDataSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/sparql/SparqlDatabaseMetadataTest.java
+++ b/src/test/java/software/aws/neptune/sparql/SparqlDatabaseMetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/sparql/SparqlManualNeptuneVerificationTest.java
+++ b/src/test/java/software/aws/neptune/sparql/SparqlManualNeptuneVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/sparql/SparqlStatementTest.java
+++ b/src/test/java/software/aws/neptune/sparql/SparqlStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/sparql/SparqlStatementTestBase.java
+++ b/src/test/java/software/aws/neptune/sparql/SparqlStatementTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/sparql/mock/SparqlMockDataQuery.java
+++ b/src/test/java/software/aws/neptune/sparql/mock/SparqlMockDataQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/sparql/mock/SparqlMockServer.java
+++ b/src/test/java/software/aws/neptune/sparql/mock/SparqlMockServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/sparql/resultset/SparqlResultSetMetadataTest.java
+++ b/src/test/java/software/aws/neptune/sparql/resultset/SparqlResultSetMetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/sparql/resultset/SparqlResultSetTest.java
+++ b/src/test/java/software/aws/neptune/sparql/resultset/SparqlResultSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/neptune/sparql/resultset/SparqlSelectResultSetGetColumnsTest.java
+++ b/src/test/java/software/aws/neptune/sparql/resultset/SparqlSelectResultSetGetColumnsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/DataTypePerformance.java
+++ b/src/test/java/software/aws/performance/DataTypePerformance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/Metric.java
+++ b/src/test/java/software/aws/performance/Metric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/PerformanceTestExecutor.java
+++ b/src/test/java/software/aws/performance/PerformanceTestExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/PerformanceTestUtils.java
+++ b/src/test/java/software/aws/performance/PerformanceTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/PerformanceTestConstants.java
+++ b/src/test/java/software/aws/performance/implementations/PerformanceTestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/executors/GremlinBaselineExecutor.java
+++ b/src/test/java/software/aws/performance/implementations/executors/GremlinBaselineExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/executors/GremlinJDBCExecutor.java
+++ b/src/test/java/software/aws/performance/implementations/executors/GremlinJDBCExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/executors/JDBCExecutor.java
+++ b/src/test/java/software/aws/performance/implementations/executors/JDBCExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/executors/OpenCypherBaselineExecutor.java
+++ b/src/test/java/software/aws/performance/implementations/executors/OpenCypherBaselineExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/executors/OpenCypherJDBCExecutor.java
+++ b/src/test/java/software/aws/performance/implementations/executors/OpenCypherJDBCExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/executors/SparqlBaselineExecutor.java
+++ b/src/test/java/software/aws/performance/implementations/executors/SparqlBaselineExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/executors/SparqlJDBCExecutor.java
+++ b/src/test/java/software/aws/performance/implementations/executors/SparqlJDBCExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/executors/SqlGremlinJDBCExecutor.java
+++ b/src/test/java/software/aws/performance/implementations/executors/SqlGremlinJDBCExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/tests/GremlinBaselineTest.java
+++ b/src/test/java/software/aws/performance/implementations/tests/GremlinBaselineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/tests/GremlinJDBCTest.java
+++ b/src/test/java/software/aws/performance/implementations/tests/GremlinJDBCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/tests/OpenCypherBaselineTest.java
+++ b/src/test/java/software/aws/performance/implementations/tests/OpenCypherBaselineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/tests/OpenCypherJDBCTest.java
+++ b/src/test/java/software/aws/performance/implementations/tests/OpenCypherJDBCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/tests/SparqlBaselineTest.java
+++ b/src/test/java/software/aws/performance/implementations/tests/SparqlBaselineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/tests/SparqlJDBCTest.java
+++ b/src/test/java/software/aws/performance/implementations/tests/SparqlJDBCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/aws/performance/implementations/tests/SqlGremlinJDBCTest.java
+++ b/src/test/java/software/aws/performance/implementations/tests/SqlGremlinJDBCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/tdvt/TDVTDataUpload.java
+++ b/src/test/java/tdvt/TDVTDataUpload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/tdvt/tdvt_csv_to_neptune_json.py
+++ b/src/test/java/tdvt/tdvt_csv_to_neptune_json.py
@@ -1,5 +1,5 @@
 #
-# Copyright <2022> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.


### PR DESCRIPTION
### Summary

Removing year from license header. 

### Description

The newer source file headers no longer include a year, so we are removing it from ours.
Year information is still included in the LICENSE file, so this wouldn't affect copyright. 

### Additional Reviewers
@birschick-bq
@xiazcy
@alexey-temnikov
@kylepbit
