### PR TITLE
Updated .taco signing trigger in build ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,15 @@ on:
 
   # Trigger on-demand
   workflow_dispatch:
-    signTacoFile:
-      description: Sign taco file artifact
-      type: boolean
-      required: false
-      default: false
+    inputs:
+      signTacoFile:
+        description: Sign taco file artifact
+        type: boolean
+        required: false
+        default: false
+
+env:
+  SIGNING_ENABLED: ${{ github.event.inputs.signTacoFile }}
 
 jobs:
   build:
@@ -60,8 +64,6 @@ jobs:
       uses: codecov/codecov-action@v3
 
   build-taco:
-    env:
-      SIGNING_ENABLED: ${{ github.event.inputs.signTacoFile }}
     name: Assemble Tableau Connector
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Summary

Updating .taco signing CI to properly accept input config events.

### Description

Fixes issue where `signTacoFile` was not correctly registering as a configurable input to the workflow.

### Related Issue

n/a

### Additional Reviewers
@birschick-bq
@xiazcy
@alexey-temnikov
@kylepbit
@Cole-Greer
