### PR TITLE
Fix Jena's initialization (#243)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -267,6 +267,7 @@ shadowJar {
         exclude(dependency('org.apache.tinkerpop::'))
         exclude(dependency('org.apache.log4j.*::'))
         exclude(dependency('com.jcraft::'))
+        exclude(dependency('org.apache.jena::'))
     }
 
     // NOTE: DO NOT relocate 'javax' 'org.apache.log4j', 'org.codehaus'

--- a/build.gradle
+++ b/build.gradle
@@ -307,4 +307,6 @@ shadowJar {
     relocate 'com.jcraft', 'shadow.com.jcraft'
     relocate 'com.squareup', 'shadow.com.squareup'
     relocate 'com.yahoo', 'shadow.com.yahoo'
+
+    mergeServiceFiles()
 }


### PR DESCRIPTION
### Summary

[Jena's initialization](https://jena.apache.org/documentation/notes/system-initialization.html) is implemented using the [ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) mechanism. This is respected when Neptune's JDBC driver [repackages Jena](https://jena.apache.org/documentation/notes/jena-repack.html).

However, when [Jena is relocated](https://github.com/aws/amazon-neptune-jdbc-driver/blob/557334258045d639517b57590a49e71a85eb7dec/build.gradle#L287) under the shadow namespace `shadow.org.apache.jena`, this namespace is not reflected in the `META-INF/services/shadow.org.apache.jena.sys.JenaSubsystemLifecycle` provider-configuration file, where the original namespace (i.e. `org.apache.jena`) is used. 

Moreover, when packaging the Neptune JDBC driver, Jena is [minimized](https://github.com/aws/amazon-neptune-jdbc-driver/blob/557334258045d639517b57590a49e71a85eb7dec/build.gradle#L265). Since the ServiceLoader providers (i.e. `shadow.org.apache.jena.riot.system.InitRIOT`, `shadow.org.apache.jena.sparql.system.InitARQ`, and `shadow.org.apache.jena.sys.InitJenaCore`) aren't referenced statically, they aren't included in the minimized package, which prevents Jena's dynamic initialization.

### Description

Rewriting fully qualified class names in the provider-configuration file can be addressed by `mergeServiceFiles()` that uses [`ServiceFileTransformer`](https://github.com/johnrengelman/shadow/blob/master/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.groovy).

Jena's dynamically loaded ServiceLoader providers can be included by excluding Jena from minimization, similarly to the [other exclusions currently used](https://github.com/aws/amazon-neptune-jdbc-driver/blob/557334258045d639517b57590a49e71a85eb7dec/build.gradle#L266-L269).

### Related Issue

#243

### Additional Reviewers

@birschick-bq
@xiazcy
@alexey-temnikov
@kylepbit
@Cole-Greer
