### PR TITLE
Remove duplicate resultSet field from PreparedStatement

### DIFF
--- a/src/main/java/software/aws/neptune/jdbc/PreparedStatement.java
+++ b/src/main/java/software/aws/neptune/jdbc/PreparedStatement.java
@@ -50,7 +50,6 @@ public class PreparedStatement extends Statement implements java.sql.PreparedSta
     private final String sql;
     @Getter
     private final QueryExecutor queryExecutor;
-    private ResultSet resultSet;
 
     /**
      * Constructor for seeding the prepared statement with the parent connection.

--- a/src/main/java/software/aws/neptune/jdbc/Statement.java
+++ b/src/main/java/software/aws/neptune/jdbc/Statement.java
@@ -43,7 +43,7 @@ public class Statement implements java.sql.Statement {
     private boolean shouldCloseOnCompletion = false;
     private SQLWarning warnings;
     private int fetchSize = 0;
-    private ResultSet resultSet;
+    protected ResultSet resultSet;
 
     /**
      * Constructor for seeding the statement with the parent connection.


### PR DESCRIPTION
### Summary

Statement is extended by PreparedStatement, and both classes currently have a field `ResultSet resultSet`.  This led to the unexpected behaviour in #235 where `getResultSet()` would return null despite the statement having a valid resultSet.

### Description

Changed resultSet in Statement from private to protected and removed the extra field from PreparedStatement so that it can inherit the field instead.

### Related Issue

https://github.com/aws/amazon-neptune-jdbc-driver/issues/235

### Additional Reviewers

