### PR TITLE
Update DbVisualizer Documentation

### DIFF
--- a/markdown/bi-tools/DbVisualizer.md
+++ b/markdown/bi-tools/DbVisualizer.md
@@ -2,7 +2,7 @@
 
 Before proceeding, ensure you have [configured your environment](../setup/configuration.md).
 
-Download the latest compatible version of [DbVisualizer](https://www.dbvis.com/) to use the Driver in DbVisualizer. Note that as of release 3.0.2, users should instead download [DbVisualizer 13](https://www.dbvis.com/download/13.0/) until the Driver is compatible with Java 17.
+Download the latest version of [DbVisualizer](https://www.dbvis.com/) to use the Driver in DbVisualizer.
 
 #### Adding the Amazon Neptune JDBC Driver to DbVisualizer
 


### PR DESCRIPTION
### Summary

DbVisualizer documentation was recently updated in #245 to recommend using DbVisualizer 13 instead of the latest release due to incompatibility with Java 17.  Upon further investigation there is no incompatibility and the latest version can be used as normal.

### Description

Reverted documentation change recommending DbVisualizer 13.

### Related Issue

### Additional Reviewers
