### PR TITLE
Fix `Assemble Tableau Connector` GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,20 +73,29 @@ jobs:
       - name: Ensure executable permissions
         run: chmod a+x ./tableau-connector/build.sh
 
-      - name: Assemble Tableau Connector
-        run: ./tableau-connector/build.sh
-
-      - name: View assembled file
-        run: ls -l tableau-connector/target
-
-      - name: Add version to TACO file
+      - name: Get driver version
         run: |
           file="./gradle.properties"
           MAJOR_VERSION=$(grep "MAJOR_VERSION" ${file} | cut -d'=' -f2)
           MINOR_VERSION=$(grep "MINOR_VERSION" ${file} | cut -d'=' -f2)
           PATCH_VERSION=$(grep "PATCH_VERSION" ${file} | cut -d'=' -f2)
           echo "version=$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION" >> $GITHUB_ENV
-          mv  tableau-connector/target/neptune-jdbc.taco tableau-connector/target/neptune-jdbc-$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION.taco
+
+      - name: Assemble Tableau Connector
+        run: ./tableau-connector/build.sh ${{env.version}}
+
+      - name: View assembled file
+        run: ls -l tableau-connector/target
+
+      - name: Verify TACO filename
+        run: |
+          if [ ! -f "tableau-connector/target/neptune-jdbc-v${{env.version}}.taco" ]
+          then
+            echo "Error: The TACO file is either incorrectly named or missing from tableau-connector/target/."
+            echo "Contents of tableau-connector/target/:"
+            ls tableau-connector/target
+            exit 1
+          fi
 
       - name: "Configure AWS credentials"
         if: ${{env.SIGNING_ENABLED == 'true'}}

--- a/tableau-connector/build.sh
+++ b/tableau-connector/build.sh
@@ -13,20 +13,33 @@ TARGET_FOLDER="$CURRENT_FOLDER"/target
 echo TARGET_FOLDER=${TARGET_FOLDER}
 mkdir -p $TARGET_FOLDER
 
+DRIVER_VERSION=$1
+if [ -z "$DRIVER_VERSION" ]
+then
+    file="../gradle.properties"
+    MAJOR_VERSION=$(grep "MAJOR_VERSION" ${file} | cut -d'=' -f2)
+    MINOR_VERSION=$(grep "MINOR_VERSION" ${file} | cut -d'=' -f2)
+    PATCH_VERSION=$(grep "PATCH_VERSION" ${file} | cut -d'=' -f2)
+    DRIVER_VERSION=$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION
+fi
+echo DRIVER_VERSION=$DRIVER_VERSION
+TACO_NAME="neptune-jdbc-v${DRIVER_VERSION}.taco"
+echo TACO_NAME=${TACO_NAME}
+
 echo "Building Docker Image"
 docker build -t taco-builder $CURRENT_FOLDER --progress=plain --no-cache
 
 echo "Assembling Tableau Connector"
 docker run -d -it --name=taco-builder --mount type=bind,source=$TARGET_FOLDER,target=/output taco-builder
 echo "Copying Tableau Connector"
-docker exec taco-builder sh -c "cp /tableau-sdk/connector-plugin-sdk/connector-packager/packaged-connector/neptune-jdbc.taco  /output"
+docker exec taco-builder sh -c "cp /tableau-sdk/connector-plugin-sdk/connector-packager/packaged-connector/$TACO_NAME /output"
 echo "Verifying Tableau Connector"
 docker exec taco-builder sh -c "ls -l /output"
 docker exec taco-builder pwd
 echo "Getting Logs"
 docker cp taco-builder:/tableau-sdk/connector-plugin-sdk/connector-packager/packaging_logs.txt $TARGET_FOLDER
 echo "Extracting Tableau Connector"
-docker cp taco-builder:/output/neptune-jdbc.taco $TARGET_FOLDER
+docker cp taco-builder:/output/$TACO_NAME $TARGET_FOLDER
 echo "Checking Logs and Resulting TACO FILE in $TARGET_FOLDER"
 ls -l $TARGET_FOLDER
 docker stop taco-builder


### PR DESCRIPTION
### Summary

The Assemble Tableau Connector workflow has been failing when attempting to append versioning to the filename.  This is caused by two points of failure:

- The taco inherits versioning from manifest.xml when being built before assembly.  `build.sh` attempts to copy `neptune-jdbc.taco` rather than `neptune-jdbc-v3.0.2.taco`, causing a failure to copy the taco into TARGET_FOLDER.

- The Assemble Tableau Connector workflow redundantly attempts to rename the taco with versioning, causing it to fail since `neptune-jdbc.taco` doesn't exist to be renamed.

### Description

- Updated taco-builder to use the correctly versioned name.
- Changed the redundant version renaming step to a filename check which makes sure versioning is included and correct. 

### Related Issue

### Additional Reviewers