### PR TITLE
Fix Taco GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Verify TACO filename
         run: |
-          if [ ! -f "tableau-connector/target/neptune-jdbc-v${{env.version}}.taco" ]
+          if [ ! -f "tableau-connector/target/neptune-jdbc-${{env.version}}.taco" ]
           then
             echo "Error: The TACO file is either incorrectly named or missing from tableau-connector/target/."
             echo "Contents of tableau-connector/target/:"


### PR DESCRIPTION
### Summary

Previous connector GHA update for naming resulted in taco signing failure due to inconsistency with current convention. Fixed here.
