### PR TITLE
Replace AuthTokens.basic with NeptuneAuthToken in OpenCypher

### DIFF
--- a/src/test/java/software/aws/neptune/opencypher/OpenCypherIAMRequestGeneratorTest.java
+++ b/src/test/java/software/aws/neptune/opencypher/OpenCypherIAMRequestGeneratorTest.java
@@ -99,8 +99,7 @@ class OpenCypherIAMRequestGeneratorTest {
 
         assertEquals(value("basic"), internalAuthToken.get(SCHEME_KEY));
         assertEquals(value(DUMMY_USERNAME), internalAuthToken.get(PRINCIPAL_KEY));
-
-        assertFalse(internalAuthToken.containsKey(REALM_KEY));
+        assertTrue(internalAuthToken.containsKey(REALM_KEY));
 
         assertTrue(internalAuthToken.containsKey(CREDENTIALS_KEY));
         final Value credentialsValue = internalAuthToken.get(CREDENTIALS_KEY);


### PR DESCRIPTION
### Summary

Automatical renewal of AWS Signature v4 authentication tokens is currently not supported, which means that after the signature expires (often in 5 minutes), the driver will fail to authenticate, and subsequent requests will fail.

### Description

This change updates the implementation of InternalAuthToken to NeptuneAuthToken, taken from [AWS Neptune documentation](https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-opencypher-bolt.html#access-graph-opencypher-bolt-java-iam-auth), so that the signature can be automatically renewed even if the connection is broken.

### Related Issue

#258 

### Additional Reviewers

